### PR TITLE
make repo injection optional, default to off

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 allprojects {
-    project.version = "0.1.0-SNAPSHOT-7"
+    project.version = "0.1.0-SNAPSHOT-8"
 }
 
 

--- a/generator-core/src/main/resources/templates/buildscript/root.build.gradle
+++ b/generator-core/src/main/resources/templates/buildscript/root.build.gradle
@@ -63,4 +63,5 @@ ignitionModule {
     <HOOK_CLASS_CONFIG>
     ]
 
+    applyInductiveArtifactRepo = true
 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -55,13 +55,17 @@ class IgnitionModlPlugin : Plugin<Project> {
             project.plugins.apply("base")
         }
 
-        addInductiveAutoRepos(project)
-
         // create the extension object used to configure the plugin in the user's buildscripts
         val settings = project.extensions.create(
             EXTENSION_NAME,
             ModuleSettings::class.java
         )
+
+        project.afterEvaluate {
+            if (settings.applyInductiveArtifactRepo.get()) {
+                addInductiveAutoRepos(project)
+            }
+        }
 
         setupRootTasks(project, settings)
         project.subprojects.forEach { p: Project ->

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
@@ -130,6 +130,11 @@ open class ModuleSettings @javax.inject.Inject constructor(objects: ObjectFactor
      */
     val requiredFrameworkVersion: Property<String> = objects.property(String::class.java)
 
+    /**
+     * If the plugin should apply the inductive maven artifact repository as a source for
+     */
+    val applyInductiveArtifactRepo: Property<Boolean> = objects.property(Boolean::class.java).convention(false)
+
     init {
         license.convention("")
         freeModule.convention(java.lang.Boolean.FALSE)


### PR DESCRIPTION
May break current uses.  If incurred, can return to earlier behavior by adding `applyInductiveArtifactRepo = true` to the module configuration. 