### PR TITLE
add support for resolving assets relative to root project in multi-mo…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 allprojects {
-    project.version = "0.1.0-SNAPSHOT-8"
+    project.version = "0.1.0-SNAPSHOT-9 "
 }
 
 


### PR DESCRIPTION
…dule projects.

This adds a property to the SignModules task that will allow (on by default) the task to try and resolve files relative to the root project, if it's different than the _module_ root project. 