### PR TITLE
add support for setting Duplicate Strategy in asset copying

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
 }
 
 allprojects {
-    project.version = "0.1.0-SNAPSHOT-9 "
+    project.version = "0.1.0-SNAPSHOT-10"
 }
 
 

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/AssembleModuleAssets.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/AssembleModuleAssets.kt
@@ -3,6 +3,7 @@ package io.ia.sdk.gradle.modl.task
 import io.ia.sdk.gradle.modl.PLUGIN_TASK_GROUP
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
@@ -36,6 +37,11 @@ open class AssembleModuleAssets @javax.inject.Inject constructor(objects: Object
     @OutputDirectory
     val moduleContentDir: DirectoryProperty = objects.directoryProperty()
 
+    @get:Input
+    val duplicateStrategy: Property<DuplicatesStrategy> = objects.property(DuplicatesStrategy::class.java).convention(
+        DuplicatesStrategy.WARN
+    )
+
     /**
      * Source directories for assets provided by subprojects
      */
@@ -56,12 +62,14 @@ open class AssembleModuleAssets @javax.inject.Inject constructor(objects: Object
             copySpec.from(sources)
             copySpec.into(moduleContentDir)
             copySpec.exclude("manifest.json")
+            copySpec.duplicatesStrategy = duplicateStrategy.get()
         }
 
         if (license.isPresent && license.get().isNotEmpty()) {
             project.copy {
                 it.from(license.get())
                 it.into(moduleContentDir)
+                it.duplicatesStrategy = duplicateStrategy.get()
             }
         }
     }


### PR DESCRIPTION
Gradle 7.0 errors if DuplicatesStrategy is not specified for Copy executions.  This change sets a default via convention, but also exposes the strategy as a configurable option on the task.  

To override the default, do something like this in your `build.gradle.kts` (or similar for `build.gradle`):

```
tasks {
     withType<AssembleModuleAssets> {
           duplicateStrategy.set(org.gradle.api.file.DuplicatesStrategy.FAIL)
     }
}

```