### PR TITLE
intermediate project artifacts, align artifact report and files

### DIFF
--- a/gradle-module-plugin/README.md
+++ b/gradle-module-plugin/README.md
@@ -28,9 +28,18 @@ The easiest way to get started with this plugin is to create a new module projec
    | keystorePassword  | gradlew signModule --keystorePassword=mysecret  | ignition.signing.keystoreFile=mysecret  |
 
 
-4. When depending on artifacts (dependencies) from the Ignition SDK, they should be specified as `compileOnly` dependencies as they will be provided by the Ignition platform at runtime.  Otherwise, your dependencies should be specified in accordance with the best practices described in Gradle's `java-library` plugin documentation, which is available [here](https://docs.gradle.org/current/userguide/java_library_plugin.html).  
+4. When depending on artifacts (dependencies) from the Ignition SDK, they should be specified as `compileOnly` dependencies as they will be provided by the Ignition platform at runtime.  Dependencies that are applied with either the `modlApi` or `modlImplementation` _Configuration_ in any subproject of your module will be collected and included in the final modl file.
+   Test and Compile-time dependencies should be specified in accordance with the best practices described in Gradle's `java-library` [plugin documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html).  See the Dependency Configuration section below for more info on configuring and managing dependencies.
 
-Dependencies marked with either `modlApi` or `modlImplementation` in any subproject of your module will be collected and included in the final modl file.  Note that currently there is no distinction between those configurations with respect to the Ignition Platform itself - however, all other implications apply as documented by the Gradle java-library plugin (e.g. - publishing, artifact uploading, transitive dependency handling, etc).  Test-only dependencies should not be marked with these `modl` configurations.
+
+Choosing which [Configuration](https://docs.gradle.org/current/userguide/declaring_dependencies.html) to apply may have important but subtle impacts on your module, as well as your development environment.  Also keep in mind the effect of _project_ dependency configurations.  
+
+> Maven Users: If you're familiar with Maven's dependency scopes, you might initially find Gradle's handling of dependencies to be unnecessarily convoluted.  This is a product of Gradle's powerful (but more complex) dependency management.  We suggest reading the gradle docs on [Working With Dependencies](https://docs.gradle.org/current/userguide/core_dependency_management.html), followed by reading the [Java Library Plugin](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation) documentation.  
+
+
+However, all other implications apply as documented by the Gradle java-library plugin (e.g. - publishing, artifact uploading, transitive dependency handling, etc).  Test-only dependencies should not be marked with these `modl` configurations.
+
+
 
 ### `ignitionModule` DSL Properties
 

--- a/gradle-module-plugin/README.md
+++ b/gradle-module-plugin/README.md
@@ -112,9 +112,39 @@ ignitionModule {
 
  # Tasks
  
- To see the tasks available, run the `tasks` gradle command, or `tasks --all` to see all possible tasks..  
+ > To see all tasks provided by the plugin, run the `tasks` gradle command, or `tasks --all` to see all possible tasks.
+
+
+The module plugin exposes a number of tasks that may be run on their own, and some which are bound to lifecycle tasks
+provided by Gradle's [Base Plugin](https://docs.gradle.org/current/userguide/base_plugin.html).  Some tasks apply
+only to the root project (the project which is applying the plugin), while others are applied to one or more 
+subprojects.  The following table is a brief reference:
+
+
+| Task  | Scope  | Description | 
+|-------|--------|-------------------------|
+| collectModlDependencies  | root and child projects  | Resolves and collects dependencies from projects with the `java-library` plugin that marked with 'modlApi/modlImplementation' configuration |
+| assembleModlStructure | aggregates assets, dependencies and assembled project jars created by the 'collectModlDependencies' task into the module staging directory |
+| writeModuleXml  | root project  | Writes the module.xml file to the staging directory  |
+| zipModule  | root project | Compresses the staged module contents into an unsigned zip archive with a .modl file extension  |
+| checksumModl  | root project  | Generates a checksum for the signed module, and writes the result to a json file  |
+| moduleAssemblyReport  | root project | Writes a json file containing meta information about the module's assembly  |
+| signModl | root project | signs the unsigned modl using credentials/certs noted above
+
+
+# How it Works
+
+This plugin is applied to a single project (the 'root' of the module) that may or may not have child projects.
+When the plugin is applied, it will attempt to identify if the root or any subprojects apply the `java-library`
+plugin. For each that does, it will add the _modlApi_ and _modlImplementation_ configurations, so that they may be used
+in the project's dependency settings. In addition, it will create the asset collection tasks and bind them to the _
+assemble_ lifecycle tasks, and ultimately establish task dependencies for the 'root-specific' tasks that create the
+module xml, copy files into the appropriate structure, zip the folder into an unsigned modl file, sign it, and report
+the result.
+
 
 # Pre-Release API Changes
 
 * v0.1.0-SNAPSHOT-6 - changed how credentials and files are specified for signing and publication.  The keys are the same, but properties are now expected to exist in a gradle.properties file, or to be specified as runtime flags as described in the Usage section above.
 * v0.1.0-SNAPSHOT-12 - added checksum generation and build report tasks.  Split repo into separate builds using gradle build composition to better isolate changes.  
+* v0.1.0-SNAPSHOT-15 - fixed dependency collection, renamed 'AssembleModuleAssets' task class and associated task

--- a/gradle-module-plugin/build.gradle
+++ b/gradle-module-plugin/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 group = "io.ia.sdk"
-version = "0.1.0-SNAPSHOT-13"
+version = "0.1.0-SNAPSHOT-14"
 
 dependencies {
     // Align versions of all Kotlin components

--- a/gradle-module-plugin/build.gradle
+++ b/gradle-module-plugin/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 group = "io.ia.sdk"
-version = "0.1.0-SNAPSHOT-12"
+version = "0.1.0-SNAPSHOT-13"
 
 dependencies {
     // Align versions of all Kotlin components

--- a/gradle-module-plugin/build.gradle
+++ b/gradle-module-plugin/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 group = "io.ia.sdk"
-version = "0.1.0-SNAPSHOT-14"
+version = "0.1.0-SNAPSHOT-15"
 
 dependencies {
     // Align versions of all Kotlin components
@@ -140,6 +140,6 @@ spotless {
     }
 }
 wrapper {
-    gradleVersion "7.0"
+    gradleVersion "7.1.1"
     distributionType org.gradle.api.tasks.wrapper.Wrapper.DistributionType.ALL
 }

--- a/gradle-module-plugin/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-module-plugin/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/CollectAndManifestDependenciesTest.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/CollectAndManifestDependenciesTest.kt
@@ -47,8 +47,8 @@ class CollectAndManifestDependenciesTest : BaseTest() {
         val manifest: ArtifactManifest = artifactManifestFromJson(manifestPath.toFile().readText(Charsets.UTF_8))
 
         assertTrue(manifest.artifacts.size == 2, "two artifacts found as expected in manifest")
-        assertNotNull(manifest.artifacts.find { it.fileName == "org.jfree.svg-4.1.jar" }, "jfree artifact exists")
-        assertNotNull(manifest.artifacts.find { it.fileName == "client-0.0.1-SNAPSHOT.jar" }, "client artifact exists")
+        assertNotNull(manifest.artifacts.find { it.jarName == "org.jfree.svg-4.1.jar" }, "jfree artifact exists")
+        assertNotNull(manifest.artifacts.find { it.jarName == "client-0.0.1-SNAPSHOT.jar" }, "client artifact exists")
 
         val dirContents = clientArtifacts.toFile().listFiles()
         assertTrue(dirContents?.size == 3, "correct number of files in artifacts dir")
@@ -87,8 +87,160 @@ class CollectAndManifestDependenciesTest : BaseTest() {
         val manifest: ArtifactManifest = artifactManifestFromJson(manifestPath.toFile().readText(Charsets.UTF_8))
 
         assertTrue(manifest.artifacts.size == 2, "two artifacts found as expected in manifest")
-        assertNotNull(manifest.artifacts.find { it.fileName == "org.jfree.svg-4.1.jar" }, "jfree artifact exists")
-        assertNotNull(manifest.artifacts.find { it.fileName == "client-0.0.1-SNAPSHOT.jar" }, "client artifact exists")
+        assertNotNull(manifest.artifacts.find { it.jarName == "org.jfree.svg-4.1.jar" }, "jfree artifact exists")
+        assertNotNull(manifest.artifacts.find { it.jarName == "client-0.0.1-SNAPSHOT.jar" }, "client artifact exists")
+
+        val dirContents = clientArtifacts.toFile().listFiles()
+        assertTrue(dirContents?.size == 3, "correct number of files in artifacts dir")
+        val jars = dirContents?.filter { it.extension == "jar" }
+        assertTrue(jars?.size == 2, "correct amount of jars in artifacts dir")
+    }
+
+    @Test
+    fun `multi scoped modlApi artifacts collected successfully with transitives`() {
+        val projectDir = tempFolder.newFolder("multiModlApiArtifacts").toPath()
+        val name = "Multiscope Artifact"
+        val jfreeLib = "modlApi('org.jfree:org.jfree.svg:4.1')"
+        val milo = "modlApi('org.eclipse.milo:sdk-server:0.6.1')"
+        val customizers = mapOf(
+            CLIENT_DEP to jfreeLib,
+            GW_DEP to milo
+        )
+
+        val config = GeneratorConfigBuilder()
+            .moduleName(name)
+            .scopes("CGD")
+            .packageName("check.my.signage")
+            .parentDir(projectDir)
+            .useRootForSingleScopeProject(false)
+            .customReplacements(customizers)
+            .build()
+
+        val project = ModuleGenerator.generate(config)
+
+        runTask(project.toFile(), "collectModlDependencies")
+
+        val clientSubproject = project.resolve("client")
+        val clientArtifacts = clientSubproject.resolve("build/artifacts")
+
+        assertTrue(clientArtifacts.toFile().exists() && clientArtifacts.toFile().isDirectory, "is dir and present")
+
+        val gwSubproject = project.resolve("gateway")
+        val gwArtifacts = gwSubproject.resolve("build/artifacts")
+
+        val expectedMiloDependencies = listOf(
+            "bcpkix-jdk15on-1.61.jar",
+            "bcprov-jdk15on-1.61.jar",
+            "bsd-core-0.6.1.jar",
+            "bsd-generator-0.6.1.jar",
+            "guava-26.0-jre.jar",
+            "istack-commons-runtime-3.0.11.jar",
+            "jakarta.activation-1.2.2.jar",
+            "jakarta.xml.bind-api-2.3.3.jar",
+            "jaxb-runtime-2.3.3.jar",
+            "netty-buffer-4.1.54.Final.jar",
+            "netty-codec-4.1.54.Final.jar",
+            "netty-codec-http-4.1.54.Final.jar",
+            "netty-common-4.1.54.Final.jar",
+            "netty-handler-4.1.54.Final.jar",
+            "netty-resolver-4.1.54.Final.jar",
+            "netty-transport-4.1.54.Final.jar",
+            "sdk-core-0.6.1.jar",
+            "sdk-server-0.6.1.jar",
+            "slf4j-api-1.7.25.jar",
+            "stack-core-0.6.1.jar",
+            "stack-server-0.6.1.jar",
+            "txw2-2.3.3.jar",
+        )
+
+        expectedMiloDependencies.forEach {
+            assertTrue(gwArtifacts.resolve(it).toFile().exists(), "Artifact $it should exist in artifacts dir.")
+        }
+
+        val manifestPath = clientArtifacts.resolve(CollectModlDependencies.JSON_FILENAME)
+        assertTrue(manifestPath.toFile().exists(), "manifest should exist")
+
+        val manifest: ArtifactManifest = artifactManifestFromJson(manifestPath.toFile().readText(Charsets.UTF_8))
+
+        assertTrue(manifest.artifacts.size == 2, "two artifacts found as expected in manifest")
+        assertNotNull(manifest.artifacts.find { it.jarName == "org.jfree.svg-4.1.jar" }, "jfree artifact exists")
+        assertNotNull(manifest.artifacts.find { it.jarName == "client-0.0.1-SNAPSHOT.jar" }, "client artifact exists")
+
+        val dirContents = clientArtifacts.toFile().listFiles()
+        assertTrue(dirContents?.size == 3, "correct number of files in artifacts dir")
+        val jars = dirContents?.filter { it.extension == "jar" }
+        assertTrue(jars?.size == 2, "correct amount of jars in artifacts dir")
+    }
+
+    @Test
+    fun `multi scoped modlImplementation artifacts collected successfully without transitives found`() {
+        val projectDir = tempFolder.newFolder("multiModlImplArtifacts").toPath()
+        val name = "Multiscope Impl Artifacts"
+        val jfreeLib = "modlApi('org.jfree:org.jfree.svg:4.1')"
+        val milo = "modlImplementation('org.eclipse.milo:sdk-server:0.6.1')"
+        val customizers = mapOf(
+            CLIENT_DEP to jfreeLib,
+            GW_DEP to milo
+        )
+
+        val config = GeneratorConfigBuilder()
+            .moduleName(name)
+            .scopes("CGD")
+            .packageName("check.my.signage")
+            .parentDir(projectDir)
+            .useRootForSingleScopeProject(false)
+            .customReplacements(customizers)
+            .build()
+
+        val project = ModuleGenerator.generate(config)
+
+        runTask(project.toFile(), "collectModlDependencies")
+
+        val clientSubproject = project.resolve("client")
+        val clientArtifacts = clientSubproject.resolve("build/artifacts")
+
+        assertTrue(clientArtifacts.toFile().exists() && clientArtifacts.toFile().isDirectory, "is dir and present")
+
+        val gwSubproject = project.resolve("gateway")
+        val gwArtifacts = gwSubproject.resolve("build/artifacts")
+
+        val expectedMiloDependencies = listOf(
+            "bcpkix-jdk15on-1.61.jar",
+            "bcprov-jdk15on-1.61.jar",
+            "bsd-core-0.6.1.jar",
+            "bsd-generator-0.6.1.jar",
+            "guava-26.0-jre.jar",
+            "istack-commons-runtime-3.0.11.jar",
+            "jakarta.activation-1.2.2.jar",
+            "jakarta.xml.bind-api-2.3.3.jar",
+            "jaxb-runtime-2.3.3.jar",
+            "netty-buffer-4.1.54.Final.jar",
+            "netty-codec-4.1.54.Final.jar",
+            "netty-codec-http-4.1.54.Final.jar",
+            "netty-common-4.1.54.Final.jar",
+            "netty-handler-4.1.54.Final.jar",
+            "netty-resolver-4.1.54.Final.jar",
+            "netty-transport-4.1.54.Final.jar",
+            "sdk-core-0.6.1.jar",
+            "sdk-server-0.6.1.jar",
+            "slf4j-api-1.7.25.jar",
+            "stack-core-0.6.1.jar",
+            "stack-server-0.6.1.jar",
+            "txw2-2.3.3.jar",
+        )
+
+        expectedMiloDependencies.forEach {
+            assertTrue(gwArtifacts.resolve(it).toFile().exists(), "Artifact $it should exist in artifacts dir.")
+        }
+
+        val manifestPath = clientArtifacts.resolve(CollectModlDependencies.JSON_FILENAME)
+        assertTrue(manifestPath.toFile().exists(), "manifest should exist")
+
+        val manifest: ArtifactManifest = artifactManifestFromJson(manifestPath.toFile().readText(Charsets.UTF_8))
+
+        assertTrue(manifest.artifacts.size == 2, "two artifacts found as expected in manifest")
+        assertNotNull(manifest.artifacts.find { it.jarName == "org.jfree.svg-4.1.jar" }, "jfree artifact exists")
+        assertNotNull(manifest.artifacts.find { it.jarName == "client-0.0.1-SNAPSHOT.jar" }, "client artifact exists")
 
         val dirContents = clientArtifacts.toFile().listFiles()
         assertTrue(dirContents?.size == 3, "correct number of files in artifacts dir")

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/CollectAndManifestDependenciesTest.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/CollectAndManifestDependenciesTest.kt
@@ -97,6 +97,47 @@ class CollectAndManifestDependenciesTest : BaseTest() {
     }
 
     @Test
+    fun `client scoped modlImplementation dependencies result in proper scope entry in manifest`() {
+        val projectDir = tempFolder.newFolder("clientScopedArtifacts").toPath()
+
+        val name = "Client Artifacts"
+
+        val dependencyEntry = "modlImplementation('org.jfree:org.jfree.svg:4.1')"
+        val customizers = mapOf(CLIENT_DEP to dependencyEntry)
+
+        val config = GeneratorConfigBuilder()
+            .moduleName(name)
+            .scopes("C")
+            .packageName("check.my.signage")
+            .parentDir(projectDir)
+            .customReplacements(customizers)
+            .useRootForSingleScopeProject(false)
+            .build()
+
+        val project = ModuleGenerator.generate(config)
+
+        runTask(project.toFile(), "collectModlDependencies")
+        val clientSubproject = project.resolve("client")
+        val clientArtifacts = clientSubproject.resolve("build/artifacts")
+
+        assertTrue(clientArtifacts.toFile().exists() && clientArtifacts.toFile().isDirectory, "is dir and present")
+
+        val manifestPath = clientArtifacts.resolve(CollectModlDependencies.JSON_FILENAME)
+        assertTrue(manifestPath.toFile().exists(), "manifest exists")
+
+        val manifest: ArtifactManifest = artifactManifestFromJson(manifestPath.toFile().readText(Charsets.UTF_8))
+
+        assertTrue(manifest.artifacts.size == 2, "two artifacts found as expected in manifest")
+        assertNotNull(manifest.artifacts.find { it.jarName == "org.jfree.svg-4.1.jar" }, "jfree artifact exists")
+        assertNotNull(manifest.artifacts.find { it.jarName == "client-0.0.1-SNAPSHOT.jar" }, "client artifact exists")
+
+        val dirContents = clientArtifacts.toFile().listFiles()
+        assertTrue(dirContents?.size == 3, "correct number of files in artifacts dir")
+        val jars = dirContents?.filter { it.extension == "jar" }
+        assertTrue(jars?.size == 2, "correct amount of jars in artifacts dir")
+    }
+
+    @Test
     fun `multi scoped modlApi artifacts collected successfully with transitives`() {
         val projectDir = tempFolder.newFolder("multiModlApiArtifacts").toPath()
         val name = "Multiscope Artifact"

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.jvm.tasks.Jar
 
 /**
  * Group used by all tasks so they show up in the appropriate category when 'gradle tasks' is executed
@@ -61,7 +62,9 @@ class IgnitionModlPlugin : Plugin<Project> {
         val settings = project.extensions.create(
             EXTENSION_NAME,
             ModuleSettings::class.java
-        )
+        ).apply {
+            this.moduleVersion.convention(project.version.toString())
+        }
 
         project.afterEvaluate {
             if (settings.applyInductiveArtifactRepo.get()) {
@@ -285,6 +288,12 @@ class IgnitionModlPlugin : Plugin<Project> {
     ): List<TaskProvider<out Task>> {
 
         p.logger.info("Setting up Java tasks on ${p.path}")
+
+        p.tasks.named("jar") {
+            if (it is Jar) {
+                it.archiveFileName.set("${p.name}-${settings.moduleVersion.get()}.jar")
+            }
+        }
 
         val assemble = p.tasks.findByName("assemble")
 

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -291,7 +291,7 @@ class IgnitionModlPlugin : Plugin<Project> {
 
         p.tasks.named("jar") {
             if (it is Jar) {
-                it.archiveFileName.set("${p.name}-${settings.moduleVersion.get()}.jar")
+                it.archiveFileName.convention("${p.name}-${settings.moduleVersion.get()}.jar")
             }
         }
 

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -5,7 +5,7 @@ import io.ia.sdk.gradle.modl.api.Constants.MODULE_API_CONFIGURATION
 import io.ia.sdk.gradle.modl.api.Constants.MODULE_IMPLEMENTATION_CONFIGURATION
 import io.ia.sdk.gradle.modl.extension.EXTENSION_NAME
 import io.ia.sdk.gradle.modl.extension.ModuleSettings
-import io.ia.sdk.gradle.modl.task.AssembleModuleAssets
+import io.ia.sdk.gradle.modl.task.AssembleModuleStructure
 import io.ia.sdk.gradle.modl.task.Checksum
 import io.ia.sdk.gradle.modl.task.CollectModlDependencies
 import io.ia.sdk.gradle.modl.task.ModuleBuildReport
@@ -137,8 +137,8 @@ class IgnitionModlPlugin : Plugin<Project> {
 
         // task that gathers dependencies and assets into a folder that will ultimately become the .modl contents
         val assembleModuleStructure = root.tasks.register(
-            AssembleModuleAssets.ID,
-            AssembleModuleAssets::class.java
+            AssembleModuleStructure.ID,
+            AssembleModuleStructure::class.java
         ) {
             it.moduleContentDir.set(root.layout.buildDirectory.dir("moduleContent"))
             it.license.set(settings.license)
@@ -240,8 +240,7 @@ class IgnitionModlPlugin : Plugin<Project> {
 
         // root project can be a module artifact contributor, so we'll apply the tasks to root as well (may opt out)
         setupDependencyTasks(root, settings)
-        rootAssemble?.dependsOn(sign)
-        rootBuild?.dependsOn(buildReport)
+        rootAssemble?.dependsOn(buildReport)
     }
 
     /**
@@ -304,7 +303,7 @@ class IgnitionModlPlugin : Plugin<Project> {
         val tasks = listOf(collectModlDependencies)
         assemble?.dependsOn(tasks)
 
-        rootModuleProject.tasks.findByName(AssembleModuleAssets.ID)?.dependsOn(collectModlDependencies)
+        rootModuleProject.tasks.findByName(AssembleModuleStructure.ID)?.dependsOn(collectModlDependencies)
 
         return tasks
     }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/model/manifests.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/model/manifests.kt
@@ -25,12 +25,12 @@ data class ArtifactManifest(
 val MOSHI: Moshi = Moshi.Builder().add(KotlinJsonAdapterFactory()).build()
 
 fun artifactManifestFromJson(json: String): ArtifactManifest {
-    val adapter = MOSHI.adapter(ArtifactManifest::class.java)
+    val adapter = MOSHI.adapter(ArtifactManifest::class.java).indent("    ")
     return adapter.fromJson(json) as ArtifactManifest
 }
 
 fun ArtifactManifest.toJson(): String {
-    val adapter = MOSHI.adapter(ArtifactManifest::class.java)
+    val adapter = MOSHI.adapter(ArtifactManifest::class.java).indent("    ")
     return adapter.toJson(this)
 }
 
@@ -67,7 +67,12 @@ data class AssemblyManifest(
     val metaInfo: Map<String, String>
 )
 
+val adapter = MOSHI.adapter(AssemblyManifest::class.java).indent("    ")
+
 fun AssemblyManifest.toJson(): String {
-    val adapter = MOSHI.adapter(AssemblyManifest::class.java)
     return adapter.toJson(this)
+}
+
+fun assemblyManifestFromJson(json: String): AssemblyManifest {
+    return adapter.fromJson(json) as AssemblyManifest
 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/model/manifests.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/model/manifests.kt
@@ -3,9 +3,17 @@ package io.ia.sdk.gradle.modl.model
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import java.io.File
 import java.io.Serializable
 
-data class Artifact(val group: String, val name: String, val version: String, val fileName: String) : Serializable
+data class FileArtifact(val id: String, val jarFile: File)
+
+data class Artifact(val id: String, val jarName: String) : Serializable {
+    constructor(fileArtifact: FileArtifact) : this(
+        fileArtifact.id,
+        fileArtifact.jarFile.name
+    )
+}
 
 data class ArtifactManifest(
     val projectPath: String,

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/AssembleModuleStructure.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/AssembleModuleStructure.kt
@@ -15,20 +15,19 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 /**
- * Task which should apply to any subproject which provides dependencies to the module in the form of jar files.
- *
- * This task is auto-applied to any module projects/subprojects which have applied the `java` plugin.
+ * Task which applies to the root gradle project (aka, the project applying the plugin) and collects the assets
+ * created by one or more [CollectModlDependencies] tasks.
  */
-open class AssembleModuleAssets @javax.inject.Inject constructor(objects: ObjectFactory) : DefaultTask() {
+open class AssembleModuleStructure @javax.inject.Inject constructor(objects: ObjectFactory) : DefaultTask() {
 
     companion object {
-        const val ID = "assembleModuleAssets"
+        const val ID = "assembleModlStructure"
     }
 
     init {
         this.group = PLUGIN_TASK_GROUP
         this.description =
-            "Assembles module assets into the 'moduleContents' folder in the module project's build directory."
+            "Assembles module assets into the 'moduleContent' folder in the module project's build directory."
     }
 
     /**

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/Checksum.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/Checksum.kt
@@ -60,7 +60,7 @@ open class Checksum @Inject constructor(_objects: ObjectFactory, _layout: Projec
         this.group = PLUGIN_TASK_GROUP
         this.description = """
             |Executes a hash function (default SHA256) against the signed modl file, and emits a json file to the build
-            | directory containing with the digest.""".trimMargin()
+            | directory containing the digest.""".trimMargin()
     }
 }
 

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/CollectModlDependencies.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/CollectModlDependencies.kt
@@ -4,10 +4,12 @@ import io.ia.sdk.gradle.modl.PLUGIN_TASK_GROUP
 import io.ia.sdk.gradle.modl.api.Constants.ARTIFACT_DIR
 import io.ia.sdk.gradle.modl.model.Artifact
 import io.ia.sdk.gradle.modl.model.ArtifactManifest
+import io.ia.sdk.gradle.modl.model.FileArtifact
 import io.ia.sdk.gradle.modl.model.IgnitionScope
 import io.ia.sdk.gradle.modl.model.toJson
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.model.ObjectFactory
@@ -19,6 +21,7 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import java.io.FileNotFoundException
 import javax.inject.Inject
 
 /**
@@ -88,34 +91,53 @@ open class CollectModlDependencies @Inject constructor(objects: ObjectFactory) :
         "${project.name}-${moduleVersion.get()}.jar"
     }
 
-    private fun buildManifest(): ArtifactManifest {
-        val apiDeps = getModlApiDeps()
-        val implDeps = getModlImplementationDeps()
-        val deps = apiDeps.dependencies + implDeps.dependencies
-        val mainArtifact = Artifact(project.group.toString(), project.name, moduleVersion.get(), versionedJarName)
-        val artifacts = deps.map {
-            Artifact(it.group.toString(), it.name, it.version.toString(), "${it.name}-${it.version}.jar")
-        } + mainArtifact
-
-        return ArtifactManifest(project.path, project.name, ignitionScope.code, artifacts)
-    }
-
-    private fun copyArtifacts() {
-        project.logger.info("Copying ${project.path} artifacts to ${artifactOutputDir.get()}")
-        project.copy { copySpec ->
-            copySpec.from(project.tasks.getByName("jar").outputs.files.toList())
-            copySpec.from(getModlApiDeps())
-            copySpec.from(getModlImplementationDeps())
-            copySpec.into(artifactOutputDir.get())
-            copySpec.rename("${project.name}\\.jar", versionedJarName)
-        }
-    }
-
     @TaskAction
     fun execute() {
-        val manifestContent = buildManifest().toJson()
+        val fileArtifacts = deriveArtifacts()
+        copyArtifacts(fileArtifacts)
+
+        // named artifacts are used in the xml, and we desire a versioned jar for the main output
+        val namedArtifacts = fileArtifacts.map {
+            Artifact(it)
+        }
+        val manifest = ArtifactManifest(project.path, project.name, ignitionScope.code, namedArtifacts)
+        val manifestContent = manifest.toJson()
         val manifestFile = manifestFile.get().asFile
         manifestFile.writeText(manifestContent, Charsets.UTF_8)
-        copyArtifacts()
+    }
+
+    private fun buildArtifactsFromArtifactView(config: Configuration): List<FileArtifact> {
+        return config.incoming.artifactView {}
+            .artifacts
+            .artifacts
+            .filterIsInstance<ResolvedArtifactResult>()
+            .map {
+                val file = it.file
+                val id = it.id
+                FileArtifact(id.displayName, file)
+            }
+    }
+
+    /**
+     * Builds a list of FileArtifacts, including the main output of the jar task for this project.  The files
+     * in this list are those being staged for inclusion in the module.
+     */
+    private fun deriveArtifacts(): List<FileArtifact> {
+        val mainJar = project.tasks.getByName("jar").outputs.files.toList().first()
+        if (!mainJar.exists()) throw FileNotFoundException("Could not identify jar task output file $mainJar")
+
+        val mainArtifact = FileArtifact("${project.group}:${project.name}:${moduleVersion.get()}", mainJar)
+        val apiDeps = buildArtifactsFromArtifactView(getModlApiDeps())
+        val implDeps = buildArtifactsFromArtifactView(getModlImplementationDeps())
+
+        return apiDeps + implDeps + mainArtifact
+    }
+
+    private fun copyArtifacts(artifacts: List<FileArtifact>) {
+        project.logger.info("Copying ${project.path} artifacts to ${artifactOutputDir.get()}")
+        project.copy { copySpec ->
+            copySpec.from(artifacts.map { it.jarFile })
+            copySpec.into(artifactOutputDir.get())
+        }
     }
 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/CollectModlDependencies.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/CollectModlDependencies.kt
@@ -86,11 +86,6 @@ open class CollectModlDependencies @Inject constructor(objects: ObjectFactory) :
     val manifestFile: Provider<RegularFile> =
         project.layout.buildDirectory.file("$ARTIFACT_DIR/$JSON_FILENAME")
 
-    @get:Input
-    val versionedJarName: String by lazy {
-        "${project.name}-${moduleVersion.get()}.jar"
-    }
-
     @TaskAction
     fun execute() {
         val fileArtifacts = deriveArtifacts()

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ModuleBuildReport.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ModuleBuildReport.kt
@@ -15,7 +15,6 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
-import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
@@ -29,19 +28,19 @@ import javax.inject.Inject
 
 open class ModuleBuildReport @Inject constructor(
     objects: ObjectFactory,
-    layout: ProjectLayout,
-    providers: ProviderFactory
+    layout: ProjectLayout
 ) : DefaultTask() {
 
     companion object {
         const val ID = "modlReport"
+        const val DEFAULT_REPORT_NAME = "buildResult.json"
     }
 
     /**
      * The name of the json file that contains build information about the module that was assembled.
      */
     @get:Input
-    val reportFileName: Property<String> = objects.property(String::class.java).convention("buildResult.json")
+    val reportFileName: Property<String> = objects.property(String::class.java).convention(DEFAULT_REPORT_NAME)
 
     /**
      * The report file that will be created by the task.

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
@@ -161,14 +161,17 @@ open class WriteModuleXml : DefaultTask() {
                     }
                 }
 
-                manifests().forEach { manifest ->
-                    manifest.artifacts.forEach { artifact ->
-                        "jar" {
-                            attribute("scope", manifest.scope)
-                            -artifact.fileName
-                        }
+                manifests().groupBy { it.scope }
+                    .forEach { (scope, manifests) ->
+                        manifests.flatMap { it.artifacts }
+                            .distinctBy { it.jarName }
+                            .forEach { artifact ->
+                                "jar" {
+                                    attribute("scope", scope)
+                                    -artifact.jarName
+                                }
+                            }
                     }
-                }
             }
         }
 


### PR DESCRIPTION
improves the accuracy resolution of artifacts marked for modl inclusion when intermediate projects are used that don't themselves generate artifacts.

