### PR TITLE
Added Development hostGateway Setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ generator-cli/out/
 generator-cli/build/
 
 gh_key
+
+# VS Code Files
+*.code-workspace
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Ignore Gradle build output directory
 build/
+bin/
 
 # Intellij / IDE files
 .idea/

--- a/generator/generator-core/src/main/resources/templates/buildscript/root.build.gradle
+++ b/generator/generator-core/src/main/resources/templates/buildscript/root.build.gradle
@@ -78,4 +78,10 @@ ignitionModule {
     // the path from the root documentation dir to the index file.
     // documentationIndex.set("index.html")
 
+    /*
+     * If the module is being automatically deployed to a development gateway, this setting can be used to specify
+     * the address of the gateway (Including IP and port)
+     */
+    hostGateway = "http://localhost:8088"
+
 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -245,6 +245,7 @@ class IgnitionModlPlugin : Plugin<Project> {
 
         root.tasks.register(Deploy.ID, Deploy::class.java) {
             it.module.convention(sign.flatMap { signTask -> signTask.signed })
+            it.hostGateway.set(settings.hostGateway)
         }
 
         // root project can be a module artifact contributor, so we'll apply the tasks to root as well (may opt out)

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
@@ -157,6 +157,14 @@ open class ModuleSettings @javax.inject.Inject constructor(objects: ObjectFactor
      */
     val documentationIndex: Property<String> = objects.property(String::class.java)
 
+     /**
+     * If the module is being deployed to a development gateawy, set this value to the host ip for the development gateway, 
+     * including protocol and port. Default is [http://localhost:8088]
+     *
+     * Optional
+     */
+    val hostGateway: Property<String> = objects.property(String::class.java).convention("http://localhost:8088")
+
     init {
         license.convention("")
         freeModule.convention(java.lang.Boolean.FALSE)

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/Deploy.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/Deploy.kt
@@ -32,7 +32,7 @@ open class Deploy @javax.inject.Inject constructor(objects: ObjectFactory) : Def
     }
 
     @get:Input
-    val hostGateway: Property<String> = objects.property(String::class.java).convention("http://localhost:8088")
+    val hostGateway: Property<String> = objects.property(String::class.java)
 
     @Option(option = "gateway", description = "Host ip for the development gateway, including protocol and port.")
     fun setGateway(url: String) {


### PR DESCRIPTION
Currently the `:deployModl` task creates a `hostGateway` property that is not accessible by the end user. This pull requests adds the setting to the `ModuleSettings.kt` file, as well as the `root.build.gradle` default file so that the user can change it as well as see how it is used.