### PR TITLE
fix common scope project dependencies

### DIFF
--- a/generator/generator-core/build.gradle.kts
+++ b/generator/generator-core/build.gradle.kts
@@ -57,12 +57,12 @@ tasks {
 dependencies {
     // Align versions of all Kotlin components
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
-
     // Use SLF4J api for logging, logger implementation to be provided by lib consumer
     api(libs.slf4jApi)
 
     // Use the Kotlin test library.
     // testImplementation(libs.bundles.kotlinTest)
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     testImplementation(kotlin("test-junit"))
 
     // support logging in tests

--- a/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/DefaultDependencies.kt
+++ b/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/DefaultDependencies.kt
@@ -1,5 +1,7 @@
 package io.ia.ignition.module.generator.api
 
+import io.ia.ignition.module.generator.api.TemplateMarker.SDK_VERSION_PLACEHOLDER
+
 object DefaultDependencies {
 
     // default gradle version
@@ -7,8 +9,6 @@ object DefaultDependencies {
 
     // default plugin configuration for the root build.gradle
     val MODL_PLUGIN: String = "id(\"io.ia.sdk.modl\") version(\"${TemplateMarker.MODL_PLUGIN_VERSION.key}\")"
-
-    const val SDK_VERSION_PLACEHOLDER = "<SDK_VERSION>"
 
     // example
     // "com.inductiveautomation.ignitionsdk:client-api:${'$'}{sdk_version}"
@@ -37,7 +37,7 @@ object DefaultDependencies {
     ): String {
         return map { artifact ->
             val version = dsl.artifactSdkVersion()
-            "$configuration(\"${artifact.replace(SDK_VERSION_PLACEHOLDER, version)}\")"
+            "$configuration(\"${artifact.replace(SDK_VERSION_PLACEHOLDER.toString(), version)}\")"
         }.joinToString(separator = "\n    ")
     }
 }

--- a/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/ProjectScope.kt
+++ b/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/ProjectScope.kt
@@ -31,7 +31,7 @@ enum class ProjectScope(val folderName: String) {
 
         /**
          * Returns a list of valid ProjectScope elements according the the string.  Lower case letters treated as
-         * upper case, and invalid scope characters in the String are ignored.  Common scope *is*  represented in
+         * upper case, and invalid scope characters in the String are ignored.  Common scope *is* represented in
          * the resulting list if the list includes more than one scope value..  Use [scopesFromShorthand] if needing
          * the exact project scopes given a shorthand string.
          */

--- a/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/TemplateMarker.kt
+++ b/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/TemplateMarker.kt
@@ -1,5 +1,10 @@
 package io.ia.ignition.module.generator.api
 
+import io.ia.ignition.module.generator.api.ProjectScope.CLIENT
+import io.ia.ignition.module.generator.api.ProjectScope.COMMON
+import io.ia.ignition.module.generator.api.ProjectScope.DESIGNER
+import io.ia.ignition.module.generator.api.ProjectScope.GATEWAY
+
 /**
  * Markers used in the various template files that are string replaced during assembly in order to create the
  * appropriately named project elements.
@@ -86,15 +91,31 @@ enum class TemplateMarker(val key: String) {
      */
     DESIGNER_DEPENDENCIES("//<DESIGNER_DEPENDENCIES>"),
 
-    DEPENDENCIES("//<DEPENDENCIES>"),
-
     JAVA_TOOLING_CONFIG("//<JAVA_TOOLING>"),
 
     SKIP_SIGNING_CONFIG("//<SKIP_MODULE_SIGNING>"),
 
-    MODL_PLUGIN_VERSION("<MODL_PLUGIN_VERSION>");
+    MODL_PLUGIN_VERSION("<MODL_PLUGIN_VERSION>"),
+
+    SDK_VERSION_PLACEHOLDER("<SDK_VERSION>");
 
     fun keys(): List<String> {
         return values().map { it.key }
+    }
+
+    override fun toString(): String {
+        return key
+    }
+
+    companion object {
+        fun dependencyKeyForScope(scope: ProjectScope): TemplateMarker? {
+            return when (scope) {
+                CLIENT -> TemplateMarker.CLIENT_DEPENDENCIES
+                DESIGNER -> TemplateMarker.DESIGNER_DEPENDENCIES
+                GATEWAY -> TemplateMarker.GATEWAY_DEPENDENCIES
+                COMMON -> TemplateMarker.COMMON_DEPENDENCIES
+                else -> null
+            }
+        }
     }
 }

--- a/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/data/ModuleGeneratorContext.kt
+++ b/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/data/ModuleGeneratorContext.kt
@@ -71,7 +71,7 @@ class ModuleGeneratorContext(override val config: GeneratorConfig) : GeneratorCo
         settingsHeaderReplacement()
         rootPluginReplacement()
         // populate the dependency replacements
-        replacements.putAll(buildDependencyEntries(scopes))
+        replacements.putAll(buildDependencyEntries(effectiveScopes))
 
         // this is a quick hack to support arbitrary replacements for resource files.  Works for now as all formal
         // template replacements are enclosed in < > characters, making collisions unlikely.

--- a/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/data/ModuleGeneratorContext.kt
+++ b/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/data/ModuleGeneratorContext.kt
@@ -14,10 +14,6 @@ import io.ia.ignition.module.generator.api.ProjectScope.GATEWAY
 import io.ia.ignition.module.generator.api.SourceFileType.JAVA
 import io.ia.ignition.module.generator.api.SourceFileType.KOTLIN
 import io.ia.ignition.module.generator.api.TemplateMarker
-import io.ia.ignition.module.generator.api.TemplateMarker.CLIENT_DEPENDENCIES
-import io.ia.ignition.module.generator.api.TemplateMarker.COMMON_DEPENDENCIES
-import io.ia.ignition.module.generator.api.TemplateMarker.DESIGNER_DEPENDENCIES
-import io.ia.ignition.module.generator.api.TemplateMarker.GATEWAY_DEPENDENCIES
 import io.ia.ignition.module.generator.api.TemplateMarker.HOOK_CLASS_CONFIG
 import io.ia.ignition.module.generator.api.TemplateMarker.MODULE_CLASSNAME
 import io.ia.ignition.module.generator.api.TemplateMarker.MODULE_FILENAME
@@ -75,25 +71,26 @@ class ModuleGeneratorContext(override val config: GeneratorConfig) : GeneratorCo
         settingsHeaderReplacement()
         rootPluginReplacement()
         // populate the dependency replacements
-        scopes.forEach {
-            @Suppress("UNUSED_EXPRESSION")
-            when (it) {
-                CLIENT -> replacements[CLIENT_DEPENDENCIES.key] =
-                    DefaultDependencies.ARTIFACTS[CLIENT]?.toDependencyFormat(config.buildDsl) ?: ""
-                DESIGNER -> replacements[DESIGNER_DEPENDENCIES.key] =
-                    DefaultDependencies.ARTIFACTS[DESIGNER]?.toDependencyFormat(config.buildDsl) ?: ""
-                GATEWAY -> replacements[GATEWAY_DEPENDENCIES.key] =
-                    DefaultDependencies.ARTIFACTS[GATEWAY]?.toDependencyFormat(config.buildDsl) ?: ""
-                COMMON -> replacements[COMMON_DEPENDENCIES.key] =
-                    DefaultDependencies.ARTIFACTS[COMMON]?.toDependencyFormat(config.buildDsl) ?: ""
-                else -> ""
-            }
-        }
+        replacements.putAll(buildDependencyEntries(scopes))
 
         // this is a quick hack to support arbitrary replacements for resource files.  Works for now as all formal
         // template replacements are enclosed in < > characters, making collisions unlikely.
         if (config.customReplacements.isNotEmpty()) {
             config.customReplacements.forEach { (k, v) -> replacements[k] = v }
+        }
+    }
+
+    private fun buildDependencyEntries(scopes: List<ProjectScope>): Map<String, String> {
+        return mutableMapOf<String, String>().apply {
+            scopes.forEach { scope ->
+                TemplateMarker.dependencyKeyForScope(scope)?.let { tm ->
+                    this[tm.key] = DefaultDependencies.ARTIFACTS[scope]?.toDependencyFormat(config.buildDsl) ?: ""
+                    // if not a common scope and there is a common project, add it as a dependency to other scopes
+                    if (scope != COMMON && scopes.size > 1) {
+                        this[tm.key] = "${this[tm.key]}\n    compileOnly(project(\":common\"))"
+                    }
+                }
+            }
         }
     }
 

--- a/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/util/generatorUtils.kt
+++ b/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/util/generatorUtils.kt
@@ -20,8 +20,8 @@ data class SubProjectSettings(
     val buildscriptLanguage: GradleDsl,
     val projectLanguage: SourceFileType,
     val scope: ProjectScope,
-    val dependencies: String = ""
-) // optional dependencies injected into build file
+    val dependencies: String = "" // optional dependencies injected into build file
+)
 
 fun buildSubProjectSettings(context: GeneratorContext, scope: ProjectScope): SubProjectSettings {
     val moduleRootDir = context.getRootDirectory()


### PR DESCRIPTION
This PR does some minor fixes so that multi-scope Ignition modules include project dependencies on the generated `common` project.  Also fixes integration test folder naming to avoid collisions.