### PR TITLE
Add ability to support "required" flag in module dependencies of module.xml

### DIFF
--- a/generator/generator-core/build.gradle.kts
+++ b/generator/generator-core/build.gradle.kts
@@ -47,10 +47,7 @@ tasks {
     named<KotlinCompile>("compileTestKotlin") {
         // don't try compiling resources that somehow end up in the test compilation path when we add the integration
         // test suite
-        sourceSets {
-            exclude("**/resources/**/*.groovy")
-            exclude("**/resources/**/*.kts")
-        }
+        exclude("**/resources/**/*.kts")
     }
 }
 

--- a/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.groovy
+++ b/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.groovy
@@ -49,7 +49,7 @@ ignitionModule {
      * for (G)ateway, (D)esigner, Vision (C)lient.
      *
      * Example:
-     * requiredModuleDependencies = [
+     * moduleDependencySpecs = [
      *    moduleId("com.inductiveautomation.vision") {
      *        it.scope = "GCD"
      *        it.required = true
@@ -63,7 +63,7 @@ ignitionModule {
      * This property will only add the "required" flag if {requiredIgnitionVersion} is at least 8.3
      *
      */
-    requiredModuleDependencies = [ ]
+    moduleDependencySpecs = [ ]
 
     /*
      * Map of fully qualified hook class to the shorthand scope.  Only one scope per hook class.

--- a/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.groovy
+++ b/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.groovy
@@ -38,8 +38,8 @@ ignitionModule {
      *
      * Example Value:
      * moduleDependencies = [
-           "com.inductiveautomation.vision": "CD",
-           "com.inductiveautomation.opcua": "G"
+     *     "com.inductiveautomation.vision": "CD",
+     *     "com.inductiveautomation.opcua": "G"
      * ]
      */
     moduleDependencies = [ : ]
@@ -49,12 +49,13 @@ ignitionModule {
      * for (G)ateway, (D)esigner, Vision (C)lient.
      *
      * Example:
-     * moduleDependencySpecs = [
-     *    moduleId("com.inductiveautomation.vision") {
-     *        it.scope = "GCD"
-     *        it.required = true
-     *    }
-     * ]
+     *   moduleDependencySpecs {
+     *      register("com.inductiveautomation.vision") {
+     *          scope = "GCD"
+     *          required = true
+     *      }
+     *      // register("com.another.mod") { ...
+     *   }
      *
      * If any of module's required module dependencies are not present, the
      * gateway will fault on loading the module.
@@ -63,7 +64,7 @@ ignitionModule {
      * This property will only add the "required" flag if {requiredIgnitionVersion} is at least 8.3
      *
      */
-    moduleDependencySpecs = [ ]
+    moduleDependencySpecs { }
 
     /*
      * Map of fully qualified hook class to the shorthand scope.  Only one scope per hook class.

--- a/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.groovy
+++ b/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.groovy
@@ -45,6 +45,27 @@ ignitionModule {
     moduleDependencies = [ : ]
 
     /*
+     * Add required module dependencies here, following the examples, with scope being one or more of G, C or D,
+     * for (G)ateway, (D)esigner, Vision (C)lient.
+     *
+     * Example:
+     * requiredModuleDependencies = [
+     *    moduleId("com.inductiveautomation.vision") {
+     *        it.scope = "GCD"
+     *        it.required = true
+     *    }
+     * ]
+     *
+     * If any of module's required module dependencies are not present, the
+     * gateway will fault on loading the module.
+     *
+     * NOTE: For modules targeting Ignition 8.3 and later. Use `moduleDependencies` for 8.1 and earlier.
+     * This property will only add the "required" flag if {requiredIgnitionVersion} is at least 8.3
+     *
+     */
+    requiredModuleDependencies = [ ]
+
+    /*
      * Map of fully qualified hook class to the shorthand scope.  Only one scope per hook class.
      *
      * Example entry: "com.myorganization.vectorizer.VectorizerDesignerHook": "D"

--- a/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.kts
+++ b/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.kts
@@ -51,12 +51,13 @@ ignitionModule {
      * for (G)ateway, (D)esigner, Vision (C)lient.
      *
      * Example:
-     * moduleDependencySpecs = setOf(
-     *    moduleId("com.inductiveautomation.reqMod") {
-     *      scope = "GCD"
-     *      required = true
-     *    }
-     * )
+     *   moduleDependencySpecs {
+     *      register("com.inductiveautomation.vision") {
+     *          scope = "GCD"
+     *          required = true
+     *      }
+     *      // register("com.another.mod") { ...
+     *   }
      *
      * If any of module's required module dependencies are not present, the
      * gateway will fault on loading the module.
@@ -65,7 +66,7 @@ ignitionModule {
      * This property will only add the "required" flag if {requiredIgnitionVersion} is at least 8.3
      *
      */
-    moduleDependencySpecs.set(setOf<RequiredModuleDependency>())
+    moduleDependencySpecs { }
 
     /*
      * Map of fully qualified hook class to the shorthand scope.  Only one scope may apply to a class, and each scope

--- a/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.kts
+++ b/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.kts
@@ -51,7 +51,7 @@ ignitionModule {
      * for (G)ateway, (D)esigner, Vision (C)lient.
      *
      * Example:
-     * requiredModuleDependencies = setOf(
+     * moduleDependencySpecs = setOf(
      *    moduleId("com.inductiveautomation.reqMod") {
      *      scope = "GCD"
      *      required = true
@@ -65,7 +65,7 @@ ignitionModule {
      * This property will only add the "required" flag if {requiredIgnitionVersion} is at least 8.3
      *
      */
-    requiredModuleDependencies.set(setOf<RequiredModuleDependency>())
+    moduleDependencySpecs.set(setOf<RequiredModuleDependency>())
 
     /*
      * Map of fully qualified hook class to the shorthand scope.  Only one scope may apply to a class, and each scope

--- a/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.kts
+++ b/generator/generator-core/src/main/resources/templates/config/modlPluginConfig.kts
@@ -47,6 +47,27 @@ ignitionModule {
     moduleDependencies.set(mapOf<String, String>())
 
     /*
+     * Add required module dependencies here, following the examples, with scope being one or more of G, C or D,
+     * for (G)ateway, (D)esigner, Vision (C)lient.
+     *
+     * Example:
+     * requiredModuleDependencies = setOf(
+     *    moduleId("com.inductiveautomation.reqMod") {
+     *      scope = "GCD"
+     *      required = true
+     *    }
+     * )
+     *
+     * If any of module's required module dependencies are not present, the
+     * gateway will fault on loading the module.
+     *
+     * NOTE: For modules targeting Ignition 8.3 and later. Use `moduleDependencies` for 8.1 and earlier.
+     * This property will only add the "required" flag if {requiredIgnitionVersion} is at least 8.3
+     *
+     */
+    requiredModuleDependencies.set(setOf<RequiredModuleDependency>())
+
+    /*
      * Map of fully qualified hook class to the shorthand scope.  Only one scope may apply to a class, and each scope
      * must have no more than single class registered.  You may omit scope registrations if they do not apply.
      *

--- a/gradle-module-plugin/README.md
+++ b/gradle-module-plugin/README.md
@@ -110,7 +110,7 @@ ignitionModule {
      *
      * Example Value:
      * moduleDependencies = [
-           "com.inductiveautomation.opcua": "G"
+     *     "com.inductiveautomation.opcua": "G"
      * ]
      */
     moduleDependencies = [ : ]   // syntax for initializing an empty map in groovy

--- a/gradle-module-plugin/README.md
+++ b/gradle-module-plugin/README.md
@@ -187,6 +187,33 @@ ignitionModule {
         "com.inductiveautomation.opcua" to "G"
     ))
 
+   /*
+    * Add required module dependencies here, following the examples, with scope being one or more of G, C or D,
+    * for (G)ateway, (D)esigner, Vision (C)lient.
+    *
+    * Example:
+    *   moduleDependencySpecs {
+    *      register("com.inductiveautomation.vision") {
+    *          scope = "GCD"
+    *          required = true
+    *      }
+    *      // register("com.another.mod") { ...
+    *   }
+    *
+    * If any of module's required module dependencies are not present, the
+    * gateway will fault on loading the module.
+    *
+    * NOTE: For modules targeting Ignition 8.3 and later. Use `moduleDependencies` for 8.1 and earlier.
+    * This property will only add the "required" flag if {requiredIgnitionVersion} is at least 8.3
+    *
+    */
+   moduleDependencySpecs { 
+       register("com.inductiveautomation.vision") {
+           scope = "CD"
+           required = true
+       }
+   }
+
     /*
      * Map of fully qualified hook class to the shorthand scope. Only one scope may apply to a class, and each scope
      * must have no more than single class registered. You may omit scope registrations if they do not apply.

--- a/gradle-module-plugin/build.gradle.kts
+++ b/gradle-module-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 group = "io.ia.sdk"
-version = "0.3.0-SNAPSHOT"
+version = "0.3.0"
 
 configurations {
     val functionalTestImplementation by registering {

--- a/gradle-module-plugin/build.gradle.kts
+++ b/gradle-module-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 group = "io.ia.sdk"
-version = "0.2.0"
+version = "0.3.0-SNAPSHOT"
 
 configurations {
     val functionalTestImplementation by registering {

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXmlTest.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXmlTest.kt
@@ -79,6 +79,10 @@ class WriteModuleXmlTest : BaseTest() {
             oneLineXml,
             """<depends scope="GCD" required="true">io.ia.modl</depends>"""
         )
+        assertContains(
+            oneLineXml,
+            """<depends scope="G" required="true">io.ia.otherModl</depends>"""
+        )
         assertEquals(
             Regex(DEPENDS).findAll(oneLineXml).toList().size,
             2
@@ -89,9 +93,10 @@ class WriteModuleXmlTest : BaseTest() {
     // @Tag("IGN-9137")
     fun `legacy module dependencies not marked at all for requiredness`() {
         val dirName = currentMethodName()
+
         val replacements = mapOf(
             "moduleDependencies = [ : ]" to
-                "moduleDependencies = [ \"io.ia.modl\" : \"GCD\" ]"
+                "moduleDependencies = ['io.ia.modl': 'GCD']"
         )
 
         val oneLineXml = generateXml(dirName, replacements)
@@ -140,7 +145,10 @@ class WriteModuleXmlTest : BaseTest() {
 
         val result: BuildResult = runTask(
             projectDir.toFile(),
-            listOf("writeModuleXml")
+            listOf(
+                "writeModuleXml",
+                "--stacktrace",
+            )
         )
 
         val task = result.task(":writeModuleXml")

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXmlTest.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXmlTest.kt
@@ -136,12 +136,18 @@ class WriteModuleXmlTest : BaseTest() {
 
     private fun generateXml(
         dirName: String,
-        replacements: Map<String, String> = mapOf()
+        replacements: Map<String, String> = mapOf(),
+        dumpBuildScript: Boolean = false,
     ): String {
         val projectDir = generateModule(
             tempFolder.newFolder(dirName),
             replacements,
         )
+
+        if (dumpBuildScript) {
+            println("build script:")
+            println(projectDir.resolve("build.gradle").readText())
+        }
 
         val result: BuildResult = runTask(
             projectDir.toFile(),

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXmlTest.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXmlTest.kt
@@ -26,9 +26,9 @@ class WriteModuleXmlTest : BaseTest() {
     fun `single module dependency marked as not required`() {
         val dirName = currentMethodName()
         val replacements = mapOf(
-            "requiredModuleDependencies = [ ]" to
+            "moduleDependencySpecs = [ ]" to
                 """
-    requiredModuleDependencies = [
+    moduleDependencySpecs = [
         moduleId("io.ia.modl") {
             it.scope = "GCD"
             it.required = false
@@ -56,9 +56,9 @@ class WriteModuleXmlTest : BaseTest() {
     fun `multiple module dependencies marked as required`() {
         val dirName = currentMethodName()
         val replacements = mapOf(
-            "requiredModuleDependencies = [ ]" to
+            "moduleDependencySpecs = [ ]" to
                 """
-    requiredModuleDependencies = [
+    moduleDependencySpecs = [
         moduleId("io.ia.modl") {
             it.scope = "GCD"
             it.required = true

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXmlTest.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXmlTest.kt
@@ -1,0 +1,155 @@
+package io.ia.sdk.gradle.modl.task
+
+import io.ia.ignition.module.generator.ModuleGenerator
+import io.ia.ignition.module.generator.api.GeneratorConfigBuilder
+import io.ia.ignition.module.generator.api.GradleDsl
+import io.ia.sdk.gradle.modl.BaseTest
+import io.ia.sdk.gradle.modl.util.collapseXmlToOneLine
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+
+class WriteModuleXmlTest : BaseTest() {
+    companion object {
+        const val MODULE_NAME = "ModuleXmlTest"
+        const val PACKAGE_NAME = "module.xml.test"
+        const val DEPENDS = "<depends"
+    }
+
+    @Test
+    // @Tag("IGN-9137")
+    fun `single module dependency marked as not required`() {
+        val dirName = currentMethodName()
+        val replacements = mapOf(
+            "requiredModuleDependencies = [ ]" to
+                """
+    requiredModuleDependencies = [
+        moduleId("io.ia.modl") {
+            it.scope = "GCD"
+            it.required = false
+        }
+    ]
+                """,
+            "requiredIgnitionVersion = \"8.0.10\"" to
+                "requiredIgnitionVersion = \"8.3.0\""
+        )
+
+        val oneLineXml = generateXml(dirName, replacements)
+
+        assertContains(
+            oneLineXml,
+            """<depends scope="GCD" required="false">io.ia.modl</depends>"""
+        )
+        assertEquals(
+            Regex(DEPENDS).findAll(oneLineXml).toList().size,
+            1
+        )
+    }
+
+    @Test
+    // @Tag("IGN-9137")
+    fun `multiple module dependencies marked as required`() {
+        val dirName = currentMethodName()
+        val replacements = mapOf(
+            "requiredModuleDependencies = [ ]" to
+                """
+    requiredModuleDependencies = [
+        moduleId("io.ia.modl") {
+            it.scope = "GCD"
+            it.required = true
+        },
+        moduleId("io.ia.otherModl") {
+            it.scope = "G"
+            it.required = true
+        }
+    ]
+                """,
+            "requiredIgnitionVersion = \"8.0.10\"" to
+                "requiredIgnitionVersion = \"8.3.0\""
+        )
+
+        val oneLineXml = generateXml(dirName, replacements)
+
+        assertContains(
+            oneLineXml,
+            """<depends scope="GCD" required="true">io.ia.modl</depends>"""
+        )
+        assertEquals(
+            Regex(DEPENDS).findAll(oneLineXml).toList().size,
+            2
+        )
+    }
+
+    @Test
+    // @Tag("IGN-9137")
+    fun `legacy module dependencies not marked at all for requiredness`() {
+        val dirName = currentMethodName()
+        val replacements = mapOf(
+            "moduleDependencies = [ : ]" to
+                "moduleDependencies = [ \"io.ia.modl\" : \"GCD\" ]"
+        )
+
+        val oneLineXml = generateXml(dirName, replacements)
+
+        assertContains(
+            oneLineXml,
+            """<depends scope="GCD">io.ia.modl</depends>"""
+        )
+        assertEquals(
+            Regex(DEPENDS).findAll(oneLineXml).toList().size,
+            1
+        )
+    }
+
+    private fun generateModule(
+        projDir: File,
+        replacements: Map<String, String> = mapOf(),
+    ): Path {
+        val config = GeneratorConfigBuilder()
+            .moduleName(MODULE_NAME)
+            .scopes("GCD")
+            .packageName(PACKAGE_NAME)
+            .parentDir(projDir.toPath())
+            .customReplacements(replacements)
+            .debugPluginConfig(true)
+            .allowUnsignedModules(true)
+            .settingsDsl(GradleDsl.GROOVY)
+            .rootPluginConfig(
+                """
+                    id("io.ia.sdk.modl")
+                """.trimIndent()
+            )
+            .build()
+
+        return ModuleGenerator.generate(config)
+    }
+
+    private fun generateXml(
+        dirName: String,
+        replacements: Map<String, String> = mapOf()
+    ): String {
+        val projectDir = generateModule(
+            tempFolder.newFolder(dirName),
+            replacements,
+        )
+
+        val result: BuildResult = runTask(
+            projectDir.toFile(),
+            listOf("writeModuleXml")
+        )
+
+        val task = result.task(":writeModuleXml")
+        assertEquals(task?.outcome, TaskOutcome.SUCCESS)
+
+        // We could do real XML parsing here but this is just a test,
+        // quick-and-dirty should be fine.
+        return collapseXmlToOneLine(
+            projectDir.resolve("build/moduleContent/module.xml").readText()
+        )
+    }
+}

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/util/utils.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/util/utils.kt
@@ -11,3 +11,8 @@ fun signedModuleName(humanModuleName: String): String {
 fun nameToDirName(moduleName: String): String {
     return moduleName.split(" ").joinToString("-") { it.lowercase() }
 }
+
+// For when you don't need full-blown XML parsing just to test. Smoosh all
+// tags together in one long line by knocking out indentation and newlines.
+fun collapseXmlToOneLine(xml: String): String =
+    xml.replace(Regex("""^\s+"""), "").replace(Regex("""\R"""), "")

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -158,7 +158,7 @@ class IgnitionModlPlugin : Plugin<Project> {
             xmlTask.moduleName.set(settings.name)
             xmlTask.moduleVersion.set(settings.moduleVersion)
             xmlTask.moduleDependencies.set(settings.moduleDependencies)
-            xmlTask.requiredModuleDependencies.set(settings.requiredModuleDependencies)
+            xmlTask.moduleDependencySpecs.set(settings.moduleDependencySpecs)
             xmlTask.requiredIgnitionVersion.set(settings.requiredIgnitionVersion)
             xmlTask.requiredFrameworkVersion.set(settings.requiredFrameworkVersion)
             xmlTask.requireFromPlatform.set(settings.requireFromPlatform)

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -158,7 +158,7 @@ class IgnitionModlPlugin : Plugin<Project> {
             xmlTask.moduleName.set(settings.name)
             xmlTask.moduleVersion.set(settings.moduleVersion)
             xmlTask.moduleDependencies.set(settings.moduleDependencies)
-            xmlTask.moduleDependencySpecs.set(settings.moduleDependencySpecs)
+            xmlTask.moduleDependencySpecs.set(settings.moduleDependencySpecs.toSet())
             xmlTask.requiredIgnitionVersion.set(settings.requiredIgnitionVersion)
             xmlTask.requiredFrameworkVersion.set(settings.requiredFrameworkVersion)
             xmlTask.requireFromPlatform.set(settings.requireFromPlatform)

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -158,6 +158,7 @@ class IgnitionModlPlugin : Plugin<Project> {
             xmlTask.moduleName.set(settings.name)
             xmlTask.moduleVersion.set(settings.moduleVersion)
             xmlTask.moduleDependencies.set(settings.moduleDependencies)
+            xmlTask.requiredModuleDependencies.set(settings.requiredModuleDependencies)
             xmlTask.requiredIgnitionVersion.set(settings.requiredIgnitionVersion)
             xmlTask.requiredFrameworkVersion.set(settings.requiredFrameworkVersion)
             xmlTask.requireFromPlatform.set(settings.requireFromPlatform)

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleDependencySpec.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleDependencySpec.kt
@@ -1,21 +1,13 @@
 package io.ia.sdk.gradle.modl.extension
 
+import org.gradle.api.Named
+import org.gradle.api.tasks.Input
 import java.io.Serializable
 
-class ModuleDependencySpec(
-    val moduleId: String,
-    val scope: String,
-    val required: Boolean
-) : Serializable
-
-@DslMarker
-annotation class ResourceDsl
-
-@ResourceDsl
-class ModuleDependencyBuilder(var moduleId: String) {
-
+abstract class ModuleDependencySpec : Named, Serializable {
+    @get:Input
     var scope: String = ""
-    var required: Boolean = false
 
-    fun build(): ModuleDependencySpec = ModuleDependencySpec(moduleId, scope, required)
+    @get:Input
+    var required: Boolean = false
 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleDependencySpec.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleDependencySpec.kt
@@ -2,7 +2,7 @@ package io.ia.sdk.gradle.modl.extension
 
 import java.io.Serializable
 
-class RequiredModuleDependency(
+class ModuleDependencySpec(
     val moduleId: String,
     val scope: String,
     val required: Boolean
@@ -17,5 +17,5 @@ class ModuleDependencyBuilder(var moduleId: String) {
     var scope: String = ""
     var required: Boolean = false
 
-    fun build(): RequiredModuleDependency = RequiredModuleDependency(moduleId, scope, required)
+    fun build(): ModuleDependencySpec = ModuleDependencySpec(moduleId, scope, required)
 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
@@ -70,16 +70,22 @@ open class ModuleSettings @javax.inject.Inject constructor(objects: ObjectFactor
 
     /**
      * List of module dependencies, which declare one or more modules you are dependent on, as well as the scope in
-     * which you depend on them, key'd on the module ID of the module depended-on, with shorthand scope value of the
-     * scope in which the module is depended.
+     * which you depend on them, keyed on the module ID of the module depended-on, with shorthand scope value of the
+     * scope in which the module is depended. Optionally, can also include whether this dependency is required as a
+     * comma separated boolean value after scope. Setting required to true will cause the module to fault on startup
+     * if the dependency is missing. Note: this flag will only be utilized on 8.3+ gateways.
      *
      * ### Examples:
      *
      * _Groovy_
      * `  moduleDependencies = [ "com.inductiveautomation.vision" : "GCD"]`
      *
+     *    moduleDependencies = [ "com.inductiveautomation.vision" : "GCD, true"]
+     *
      * _Kotlin_
      * `  moduleDependencies = mapOf("com.inductiveautomation.vision" to "GCD")`
+     *
+     *    moduleDependencies = mapOf("com.inductiveautomation.vision" to "GCD, true")
      */
     val moduleDependencies: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
 

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
@@ -82,6 +82,7 @@ open class ModuleSettings @javax.inject.Inject constructor(objects: ObjectFactor
      * _Kotlin_
      * `  moduleDependencies = mapOf("com.inductiveautomation.vision" to "GCD")`
      */
+    @Deprecated("Use new moduleDependencySpecs")
     val moduleDependencies: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
 
     /**

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
@@ -3,11 +3,12 @@ package io.ia.sdk.gradle.modl.extension
 import io.ia.sdk.gradle.modl.task.HashAlgorithm
 import io.ia.sdk.gradle.modl.task.ZipModule
 import io.ia.sdk.gradle.modl.util.capitalize
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
 
 const val EXTENSION_NAME = "ignitionModule"
 
@@ -20,7 +21,7 @@ const val EXTENSION_NAME = "ignitionModule"
  *        reflected in the module.xml file that is generated and placed in the root of your assembled module by the plugin
  *     2. It identifies the project or subprojects that are to be included by your
  */
-open class ModuleSettings @javax.inject.Inject constructor(objects: ObjectFactory) {
+abstract class ModuleSettings @javax.inject.Inject constructor(objects: ObjectFactory) {
 
     /**
      * The 'name' of your module as is displayed in the Ignition Gateway configuration page when the module is installed.
@@ -77,7 +78,7 @@ open class ModuleSettings @javax.inject.Inject constructor(objects: ObjectFactor
      * ### Examples:
      *
      * _Groovy_
-     * `  moduleDependencies = [ "com.inductiveautomation.vision" : "GCD"]`
+     * `  moduleDependencies = ["com.inductiveautomation.vision": "GCD"]`
      *
      * _Kotlin_
      * `  moduleDependencies = mapOf("com.inductiveautomation.vision" to "GCD")`
@@ -93,34 +94,26 @@ open class ModuleSettings @javax.inject.Inject constructor(objects: ObjectFactor
      * ### Examples:
      *
      * _Groovy_
-     *   moduleDependencySpecs = [
-     *      moduleId("com.inductiveautomation.vision") {
-     *          it.scope = "GCD"
-     *          it.required = true
-     *      }
-     *   ]
-     *
-     * _Kotlin_
-     *   moduleDependencySpecs = setOf(
-     *      moduleId("com.inductiveautomation.vision") {
+     *   moduleDependencySpecs {
+     *      register("com.inductiveautomation.vision") {
      *          scope = "GCD"
      *          required = true
      *      }
-     *   )
+     *      // register("com.another.mod") { ...
+     *   }
+     *
+     * _Kotlin_
+     *   moduleDependencySpecs {
+     *      register("com.inductiveautomation.vision") {
+     *          scope = "GCD"
+     *          required = true
+     *      }
+     *      // register("com.another.mod") { ...
+     *   }
      */
-    val moduleDependencySpecs: SetProperty<ModuleDependencySpec> = objects.setProperty(
-        ModuleDependencySpec::class.java
-    ).convention(
-        moduleDependencies.map {
-            it.map { (moduleId, scope) -> ModuleDependencySpec(moduleId, scope, false) }
-        }
-    )
-
-    /**
-     * Helper DSL function for moduleDependencySpecs.
-     */
-    fun moduleId(moduleId: String, block: ModuleDependencyBuilder.() -> Unit): ModuleDependencySpec =
-        ModuleDependencyBuilder(moduleId).apply(block).build()
+    @get:Input
+    val moduleDependencySpecs: NamedDomainObjectContainer<ModuleDependencySpec> =
+        objects.domainObjectContainer(ModuleDependencySpec::class.java)
 
     /**
      * Map of Ignition Scope to fully qualified hook class to, where scope is one of "C", "D", "G" for "vision Client",

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
@@ -86,13 +86,13 @@ open class ModuleSettings @javax.inject.Inject constructor(objects: ObjectFactor
 
     /**
      * New version of moduleDependencies for 8.3+ which allows for the addition of a "required" flag to be specified.
-     * Uses a builder to construct the property so the RequiredModuleDependency piece can be extrapolated away.
+     * Uses a builder to construct the property so the ModuleDependencySpec piece can be extrapolated away.
      * Note: This required flag will only be put in the XML if requiredIgnitionVersion is explicitly set to 8.3+.
      *
      * ### Examples:
      *
      * _Groovy_
-     *   requiredModuleDependencies = [
+     *   moduleDependencySpecs = [
      *      moduleId("com.inductiveautomation.vision") {
      *          it.scope = "GCD"
      *          it.required = true
@@ -100,25 +100,25 @@ open class ModuleSettings @javax.inject.Inject constructor(objects: ObjectFactor
      *   ]
      *
      * _Kotlin_
-     *   requiredModuleDependencies = setOf(
+     *   moduleDependencySpecs = setOf(
      *      moduleId("com.inductiveautomation.vision") {
      *          scope = "GCD"
      *          required = true
      *      }
      *   )
      */
-    val requiredModuleDependencies: SetProperty<RequiredModuleDependency> = objects.setProperty(
-        RequiredModuleDependency::class.java
+    val moduleDependencySpecs: SetProperty<ModuleDependencySpec> = objects.setProperty(
+        ModuleDependencySpec::class.java
     ).convention(
         moduleDependencies.map {
-            it.map { (moduleId, scope) -> RequiredModuleDependency(moduleId, scope, false) }
+            it.map { (moduleId, scope) -> ModuleDependencySpec(moduleId, scope, false) }
         }
     )
 
     /**
-     * Helper DSL function for requiredModuleDependencies.
+     * Helper DSL function for moduleDependencySpecs.
      */
-    fun moduleId(moduleId: String, block: ModuleDependencyBuilder.() -> Unit): RequiredModuleDependency =
+    fun moduleId(moduleId: String, block: ModuleDependencyBuilder.() -> Unit): ModuleDependencySpec =
         ModuleDependencyBuilder(moduleId).apply(block).build()
 
     /**

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/RequiredModuleDependency.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/RequiredModuleDependency.kt
@@ -1,0 +1,21 @@
+package io.ia.sdk.gradle.modl.extension
+
+import java.io.Serializable
+
+class RequiredModuleDependency(
+    val moduleId: String,
+    val scope: String,
+    val required: Boolean
+) : Serializable
+
+@DslMarker
+annotation class ResourceDsl
+
+@ResourceDsl
+class ModuleDependencyBuilder(var moduleId: String) {
+
+    var scope: String = ""
+    var required: Boolean = false
+
+    fun build(): RequiredModuleDependency = RequiredModuleDependency(moduleId, scope, required)
+}

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
@@ -151,9 +151,13 @@ open class WriteModuleXml @Inject constructor(_objects: ObjectFactory) : Default
                     }
                 }
 
-                moduleDependencies.get().forEach { moduleId, scope ->
+                moduleDependencies.get().forEach { moduleId, item ->
                     "depends" {
-                        attribute("scope", scope)
+                        val scopeAndRequired = item.split(",")
+                        attribute("scope", scopeAndRequired[0])
+                        if (scopeAndRequired.size == 2) {
+                            attribute("required", scopeAndRequired[1].trim())
+                        }
                         -moduleId
                     }
                 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
@@ -85,6 +85,11 @@ open class WriteModuleXml @Inject constructor(_objects: ObjectFactory) : Default
     val moduleDependencies: MapProperty<String, String> =
         _objects.mapProperty(String::class.java, String::class.java)
 
+    /**
+     * Structured replacement for [moduleDependencies], including moduleId,
+     * scope, and whether the gateway should tolerate whether each dependency
+     * loads or not prior to loading the current module.
+     */
     @get:Input
     @get:Optional
     val moduleDependencySpecs: SetProperty<ModuleDependencySpec> =
@@ -171,7 +176,7 @@ open class WriteModuleXml @Inject constructor(_objects: ObjectFactory) : Default
                         "depends" {
                             attribute("scope", dependency.scope)
                             if (usemoduleDependencySpecs()) attribute("required", dependency.required)
-                            -dependency.moduleId
+                            -dependency.name
                         }
                     }
                 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
@@ -164,19 +164,19 @@ open class WriteModuleXml @Inject constructor(_objects: ObjectFactory) : Default
                     }
                 }
 
-                if (moduleDependencies.isPresent && moduleDependencies.get().isNotEmpty()) {
-                    moduleDependencies.get().forEach { moduleId, scope ->
-                        "depends" {
-                            attribute("scope", scope)
-                            -moduleId
-                        }
-                    }
-                } else if (moduleDependencySpecs.isPresent) {
+                if (moduleDependencySpecs.isPresent && moduleDependencySpecs.get().isNotEmpty()) {
                     moduleDependencySpecs.get().forEach { dependency ->
                         "depends" {
                             attribute("scope", dependency.scope)
                             if (usemoduleDependencySpecs()) attribute("required", dependency.required)
                             -dependency.name
+                        }
+                    }
+                } else if (moduleDependencies.isPresent) {
+                    moduleDependencies.get().forEach { moduleId, scope ->
+                        "depends" {
+                            attribute("scope", scope)
+                            -moduleId
                         }
                     }
                 }
@@ -214,8 +214,10 @@ open class WriteModuleXml @Inject constructor(_objects: ObjectFactory) : Default
     private fun usemoduleDependencySpecs(): Boolean {
         if (!requiredIgnitionVersion.isPresent) return false
 
-        val version = requiredIgnitionVersion.get().split(".")
-        return version.size >= 2 && version[0].toInt() >= 8 && version[1].toInt() >= 3
+        val version = requiredIgnitionVersion.get().split(".").map { it.toInt() }
+        if (version[0] >= 9) { return true }
+        if (version[0] == 8 && version[1] >= 3) { return true }
+        return false
     }
 
     private fun manifests(): List<ArtifactManifest> {

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
@@ -1,7 +1,7 @@
 package io.ia.sdk.gradle.modl.task
 
 import io.ia.sdk.gradle.modl.PLUGIN_TASK_GROUP
-import io.ia.sdk.gradle.modl.extension.RequiredModuleDependency
+import io.ia.sdk.gradle.modl.extension.ModuleDependencySpec
 import io.ia.sdk.gradle.modl.model.ArtifactManifest
 import io.ia.sdk.gradle.modl.model.artifactManifestFromJson
 import org.gradle.api.DefaultTask
@@ -86,8 +86,8 @@ open class WriteModuleXml @Inject constructor(_objects: ObjectFactory) : Default
 
     @get:Input
     @get:Optional
-    val requiredModuleDependencies: SetProperty<RequiredModuleDependency> =
-        _objects.setProperty(RequiredModuleDependency::class.java)
+    val moduleDependencySpecs: SetProperty<ModuleDependencySpec> =
+        _objects.setProperty(ModuleDependencySpec::class.java)
 
     @get:Input
     @get:Optional
@@ -165,11 +165,11 @@ open class WriteModuleXml @Inject constructor(_objects: ObjectFactory) : Default
                             -moduleId
                         }
                     }
-                } else if (requiredModuleDependencies.isPresent) {
-                    requiredModuleDependencies.get().forEach { dependency ->
+                } else if (moduleDependencySpecs.isPresent) {
+                    moduleDependencySpecs.get().forEach { dependency ->
                         "depends" {
                             attribute("scope", dependency.scope)
-                            if (useRequiredModuleDependencies()) attribute("required", dependency.required)
+                            if (usemoduleDependencySpecs()) attribute("required", dependency.required)
                             -dependency.moduleId
                         }
                     }
@@ -205,7 +205,7 @@ open class WriteModuleXml @Inject constructor(_objects: ObjectFactory) : Default
         return modules.toString(PrintOptions(pretty = true, singleLineTextElements = true, useSelfClosingTags = false))
     }
 
-    private fun useRequiredModuleDependencies(): Boolean {
+    private fun usemoduleDependencySpecs(): Boolean {
         if (!requiredIgnitionVersion.isPresent) return false
 
         val version = requiredIgnitionVersion.get().split(".")

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
@@ -81,6 +81,7 @@ open class WriteModuleXml @Inject constructor(_objects: ObjectFactory) : Default
      */
     @get:Input
     @get:Optional
+    @Deprecated("Use new moduleDependencySpecs")
     val moduleDependencies: MapProperty<String, String> =
         _objects.mapProperty(String::class.java, String::class.java)
 


### PR DESCRIPTION
This PR introduces a new flag to the `ModuleSettings` class called `requiredModuleDependencies`. This flag is intended as a substitute for the existing `moduleDependencies`, not a replacement. Current module builds should be unaffected.

In order to utilize this flag, `requiredIgnitionVersion` will need to also be set to at least 8.3.0. To simplify the usage of this new property, this PR also adds a Kotlin DSL to parse user input into a new `RequiredModuleDependency` class. Usage of this DSL is in the following form:
```
requiredModuleDependencies = setOf(
     moduleId("com.inductiveautomation.vision") {
         scope = "GCD"
         required = true
     }
)
```

This PR also includes unit tests for the `WriteModuleXml` class which previously had none. These tests are for usage of both the new flag as well as the original.