### PR TITLE
De-duplicate Module.xml jar entries based on scope.

### DIFF
--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXmlTest.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXmlTest.kt
@@ -7,6 +7,7 @@ import io.ia.ignition.module.generator.api.ProjectScope
 import io.ia.ignition.module.generator.util.replacePlaceholders
 import io.ia.sdk.gradle.modl.BaseTest
 import io.ia.sdk.gradle.modl.util.collapseXmlToOneLine
+import io.ia.sdk.gradle.modl.util.splitXmlNodesToList
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
 import java.io.File
@@ -48,8 +49,8 @@ class WriteModuleXmlTest : BaseTest() {
             """<depends scope="GCD" required="false">io.ia.modl</depends>"""
         )
         assertEquals(
+            1,
             Regex(DEPENDS).findAll(oneLineXml).toList().size,
-            1
         )
     }
 
@@ -86,8 +87,8 @@ class WriteModuleXmlTest : BaseTest() {
             """<depends scope="G" required="true">io.ia.otherModl</depends>"""
         )
         assertEquals(
+            2,
             Regex(DEPENDS).findAll(oneLineXml).toList().size,
-            2
         )
     }
 
@@ -125,7 +126,6 @@ class WriteModuleXmlTest : BaseTest() {
         val oneLineXml = generateXml(
             dirName,
             replacements,
-            // true,
         )
 
         assertContains(
@@ -137,8 +137,8 @@ class WriteModuleXmlTest : BaseTest() {
             """<depends scope="G" required="true">io.ia.otherModl</depends>"""
         )
         assertEquals(
+            2,
             Regex(DEPENDS).findAll(oneLineXml).toList().size,
-            2
         )
     }
 
@@ -159,14 +159,14 @@ class WriteModuleXmlTest : BaseTest() {
             """<depends scope="GCD">io.ia.modl</depends>"""
         )
         assertEquals(
+            1,
             Regex(DEPENDS).findAll(oneLineXml).toList().size,
-            1
         )
     }
 
     @Test
     // @Tag ("IGN-10612")
-    fun `jars are included, de-duplicated, and sorted`() {
+    fun `jars are de-duplicated and sorted with --foldJars option`() {
         val dirName = currentMethodName()
         val dependencies = mapOf<String, String>(
             // JLA-1.5 pulls in commons-math3-3.5 as transitive dep
@@ -179,33 +179,98 @@ class WriteModuleXmlTest : BaseTest() {
             // Pulls in commons-pool-1.5.4 as transitive dep
             "DG" to "modlApi 'commons-dbcp:commons-dbcp:1.4'",
             "CD" to "modlApi 'args4j:args4j:2.0.8'",
+            // Translates to shorthand A[ll]
             "CDG" to "modlApi 'com.inductiveautomation.ignition:ia-gson:2.10.1'",
         )
 
-        val oneLineXml = generateXml(dirName, emptyMap(), dependencies)
+        val oneLineXml = generateXml(
+            dirName = dirName,
+            replacements = emptyMap(),
+            dependencies = dependencies,
+            foldJars = true,
+        )
 
         // Split to list on the whitespace between nodes, extract <jar/>s.
-        val jars =
-            oneLineXml.split(Regex("""(?<=>)\s+(?=<)"""))
-                .filter { node -> node.startsWith("<jar") }
+        val jars = splitXmlNodesToList(oneLineXml, listOf("jar"))
 
         assertEquals(
-            jars,
             listOf(
-                """<jar scope="CDG">common-0.0.1-SNAPSHOT.jar</jar>""",
-                """<jar scope="CDG">ia-gson-2.10.1.jar</jar>""",
-                """<jar scope="CDG">javassist-3.12.1.GA.jar</jar>""",
                 """<jar scope="CD">args4j-2.0.8.jar</jar>""",
                 """<jar scope="CD">client-0.0.1-SNAPSHOT.jar</jar>""",
                 """<jar scope="CD">jline-2.12.jar</jar>""",
+
                 """<jar scope="DG">commons-dbcp-1.4.jar</jar>""",
                 """<jar scope="DG">commons-pool-1.5.4.jar</jar>""",
+
+                """<jar scope="A">common-0.0.1-SNAPSHOT.jar</jar>""",
+                """<jar scope="A">ia-gson-2.10.1.jar</jar>""",
+                """<jar scope="A">javassist-3.12.1.GA.jar</jar>""",
+
                 """<jar scope="D">designer-0.0.1-SNAPSHOT.jar</jar>""",
                 """<jar scope="D">duckdb_jdbc-0.9.2.jar</jar>""",
+
                 """<jar scope="G">JLargeArrays-1.5.jar</jar>""",
                 """<jar scope="G">commons-math3-3.5.jar</jar>""",
                 """<jar scope="G">gateway-0.0.1-SNAPSHOT.jar</jar>""",
-            )
+            ),
+            jars,
+        )
+    }
+
+    @Test
+    // @Tag ("IGN-10612")
+    fun `jars are written largely as-is by default`() {
+        val dirName = currentMethodName()
+        val dependencies = mapOf<String, String>(
+            // JLA-1.5 pulls in commons-math3-3.5 as transitive dep
+            "G" to "modlApi 'pl.edu.icm:JLargeArrays:1.5'",
+            "D" to "modlApi 'org.duckdb:duckdb_jdbc:0.9.2'",
+            // C[lient] implies D[esigner], so here C -> CD
+            "C" to "modlApi 'jline:jline:2.12'",
+            // Similarly, here CG -> CD and separately G
+            "CG" to "modlApi 'javassist:javassist:3.12.1.GA'",
+            // Pulls in commons-pool-1.5.4 as transitive dep
+            "DG" to "modlApi 'commons-dbcp:commons-dbcp:1.4'",
+            "CD" to "modlApi 'args4j:args4j:2.0.8'",
+            "CDG" to "modlApi 'com.inductiveautomation.ignition:ia-gson:2.10.1'",
+        )
+
+        val oneLineXml = generateXml(
+            dirName = dirName,
+            replacements = emptyMap(),
+            dependencies = dependencies,
+            // default is foldJars = false,
+        )
+
+        // Split to list on the whitespace between nodes, extract <jar/>s.
+        val jars = splitXmlNodesToList(oneLineXml, listOf("jar"))
+
+        assertEquals(
+            listOf(
+                """<jar scope="CD">ia-gson-2.10.1.jar</jar>""",
+                """<jar scope="CD">args4j-2.0.8.jar</jar>""",
+                """<jar scope="CD">javassist-3.12.1.GA.jar</jar>""",
+                """<jar scope="CD">jline-2.12.jar</jar>""",
+                """<jar scope="CD">client-0.0.1-SNAPSHOT.jar</jar>""",
+
+                """<jar scope="CDG">common-0.0.1-SNAPSHOT.jar</jar>""",
+
+                """<jar scope="D">ia-gson-2.10.1.jar</jar>""",
+                """<jar scope="D">args4j-2.0.8.jar</jar>""",
+                """<jar scope="D">commons-dbcp-1.4.jar</jar>""",
+                """<jar scope="D">duckdb_jdbc-0.9.2.jar</jar>""",
+                """<jar scope="D">commons-pool-1.5.4.jar</jar>""",
+                """<jar scope="D">designer-0.0.1-SNAPSHOT.jar</jar>""",
+
+                """<jar scope="G">ia-gson-2.10.1.jar</jar>""",
+                """<jar scope="G">commons-dbcp-1.4.jar</jar>""",
+                """<jar scope="G">javassist-3.12.1.GA.jar</jar>""",
+                """<jar scope="G">JLargeArrays-1.5.jar</jar>""",
+                """<jar scope="G">commons-pool-1.5.4.jar</jar>""",
+                """<jar scope="G">commons-math3-3.5.jar</jar>""",
+                """<jar scope="G">gateway-0.0.1-SNAPSHOT.jar</jar>""",
+            ),
+            jars,
         )
     }
 
@@ -236,6 +301,7 @@ class WriteModuleXmlTest : BaseTest() {
         dirName: String,
         replacements: Map<String, String> = mapOf(),
         dependencies: Map<String, String> = mapOf(),
+        foldJars: Boolean = false,
         dumpBuildScript: Boolean = false,
     ): String {
         val projectDir = generateModule(
@@ -260,16 +326,21 @@ class WriteModuleXmlTest : BaseTest() {
             println(projectDir.resolve("build.gradle").readText())
         }
 
+        val args = mutableListOf(
+            // "--stacktrace",
+            "writeModuleXml",
+        )
+        if (foldJars) {
+            args.add("--foldJars")
+        }
+
         val result: BuildResult = runTask(
             projectDir.toFile(),
-            listOf(
-                "writeModuleXml",
-                "--stacktrace",
-            )
+            args,
         )
 
         val task = result.task(":writeModuleXml")
-        assertEquals(task?.outcome, TaskOutcome.SUCCESS)
+        assertEquals(TaskOutcome.SUCCESS, task?.outcome)
 
         // We could do real XML parsing here but this is just a test,
         // quick-and-dirty should be fine.

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/util/utils.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/util/utils.kt
@@ -16,3 +16,16 @@ fun nameToDirName(moduleName: String): String {
 // tags together in one long line by knocking out indentation and newlines.
 fun collapseXmlToOneLine(xml: String): String =
     xml.replace(Regex("""^\s+"""), "").replace(Regex("""\R"""), "")
+
+// Likewise, for when it's useful to break XML nodes out to a list of node
+// names. With optional inclusive filter.
+fun splitXmlNodesToList(
+    xml: String,
+    nodeFilter: List<String> = listOf<String>(),
+): List<String> =
+    xml.split(Regex("""(?<=>)\s+(?=<)"""))
+        .filter { n ->
+            // if no filter, include; else look for BOL with matching tag
+            nodeFilter.isEmpty() ||
+                nodeFilter.any { nf -> n.startsWith("<$nf") }
+        }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/model/Models.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/model/Models.kt
@@ -28,10 +28,11 @@ enum class IgnitionScope(val code: String) {
     GATEWAY_DESIGNER("DG"),
     GATEWAY_DESIGNER_VISION_CLIENT("CDG"),
     GATEWAY_VISION_CLIENT("CG"),
+    ALL("A"),
     NONE("");
 
     companion object {
-        private val VALID_SCOPES = Regex("^[GCD]+\$")
+        private val VALID_SCOPES = Regex("^[AGCD]+\$")
 
         /**
          * Applies simplistic validation to the string and returns the corresponding scope if it can be determined.
@@ -60,8 +61,20 @@ enum class IgnitionScope(val code: String) {
                 "CDG" -> GATEWAY_DESIGNER_VISION_CLIENT
                 "DG" -> GATEWAY_DESIGNER
                 "CG" -> GATEWAY_VISION_CLIENT
+                "A" -> ALL
                 else -> throw Exception("Could not determine IgnitionScope for shorthand '$code'")
             }
         }
+
+        /**
+         * Performs 'CDG'-to-'A' transform when applicable.
+         */
+        @JvmStatic
+        @Throws(ModuleConfigException::class)
+        fun promoteToAllWhenImplied(scopes: String): IgnitionScope =
+            forShorthand(scopes).let { scope ->
+                if (scope == GATEWAY_DESIGNER_VISION_CLIENT)
+                    ALL else scope
+            }
     }
 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
@@ -223,17 +223,15 @@ open class WriteModuleXml @Inject constructor(_objects: ObjectFactory) : Default
                 .flatMap { mani -> mani.artifacts }
                 .groupBy { arti -> arti.jarName }
                 .map { (jar, artifacts) ->
-                    Pair(
-                        jar,
-                        // Combine all scopes for the artifact
-                        artifacts.fold(setOf<Char>()) { scope, arti ->
-                            scope.union(
-                                manifests
-                                    .filter { mani -> arti in mani.artifacts }
-                                    .flatMap { mani -> mani.scope.toList() }
-                            )
-                        }.joinToString("")
-                    )
+                    val combinedScope = artifacts.fold(setOf<Char>()) { scope, arti ->
+                        scope.union(
+                            manifests
+                                .filter { mani -> arti in mani.artifacts }
+                                .flatMap { mani -> mani.scope.toList() }
+                        )
+                    }.joinToString("")
+
+                    jar to combinedScope
                 }.sortedWith(
                     compareByDescending<Pair<String, String>> { (_, scope) -> scope.length }
                         .thenBy { (_, scope) -> scope }


### PR DESCRIPTION
The logic:
1. Group the manifests by `jarName`.
2. For each `jarName`, find all the scopes where it is applied and append them together in a list using `flatMap`.
3. Convert this list of scopes to a set in order to deduplicate, then join back together into a string.

At this point the de-duplication is complete and the original issue is resolved. https://github.com/inductiveautomation/ignition-module-tools/issues/52

I think it would also be a good idea to force a sort order for the jars, so I added it in.

1. Sort by `scope` length (jars used in more places are listed first).
2. Sort by `scope` alphabetically
3. Sort by `jarName` alphabetically

---
Before:
```xml
<jar scope="C">core-client-0.1.0.jar</jar>
<jar scope="C">kotlin-stdlib-2.0.0.jar</jar>
<jar scope="C">annotations-13.0.jar</jar>
<jar scope="C">if97-steam-tables-client-0.1.0.jar</jar>
<jar scope="CDG">core-common-0.3.0.jar</jar>
<jar scope="CDG">if97-2.0.0.jar</jar>
<jar scope="CDG">kotlin-stdlib-2.0.0.jar</jar> 
<jar scope="CDG">annotations-13.0.jar</jar>
<jar scope="CDG">if97-steam-tables-common-0.1.0.jar</jar>
<jar scope="D">core-designer-0.3.0.jar</jar>
<jar scope="D">kotlin-stdlib-2.0.0.jar</jar>
<jar scope="D">annotations-13.0.jar</jar>
<jar scope="D">if97-steam-tables-designer-0.1.0.jar</jar>
<jar scope="G">core-gateway-0.3.0.jar</jar>
<jar scope="G">kotlin-stdlib-2.0.0.jar</jar>
<jar scope="G">annotations-13.0.jar</jar>
<jar scope="G">if97-steam-tables-gateway-0.1.0.jar</jar>
```

---

After:
```xml
<jar scope="CDG">annotations-13.0.jar</jar>
<jar scope="CDG">core-common-0.3.0.jar</jar>
<jar scope="CDG">if97-2.0.0.jar</jar>
<jar scope="CDG">if97-steam-tables-common-0.1.0.jar</jar>
<jar scope="CDG">kotlin-stdlib-2.0.0.jar</jar>
<jar scope="C">core-client-0.1.0.jar</jar>
<jar scope="C">if97-steam-tables-client-0.1.0.jar</jar>
<jar scope="D">core-designer-0.3.0.jar</jar>
<jar scope="D">if97-steam-tables-designer-0.1.0.jar</jar>
<jar scope="G">core-gateway-0.3.0.jar</jar>
<jar scope="G">if97-steam-tables-gateway-0.1.0.jar</jar>
```

