### PR TITLE
Dev window release version prep

### DIFF
--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
 }
 
 allprojects {
-    project.version = "0.1.0-SNAPSHOT"
+    project.version = "0.4.0-SNAPSHOT"
 }
 
 tasks {

--- a/generator/generator-cli/src/main/kotlin/io/ia/sdk/tools/module/cli/ModuleGeneratorCli.kt
+++ b/generator/generator-cli/src/main/kotlin/io/ia/sdk/tools/module/cli/ModuleGeneratorCli.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.Callable
 
 @Command(
     name = "ignition-module-gen",
-    version = ["0.0.2"],
+    version = ["0.4.0-SNAPSHOT"],
     description = ["Generates an Ignition module skeleton according to provided arguments."],
     subcommands = [HelpCommand::class],
     mixinStandardHelpOptions = true
@@ -160,7 +160,7 @@ class ModuleGeneratorCli : Callable<Int> {
             configBuilder.debugPluginConfig(true)
             configBuilder.rootPluginConfig("""id("io.ia.sdk.modl")""")
         } else {
-            configBuilder.rootPluginConfig("""id("io.ia.sdk.modl") version("0.1.1")""")
+            configBuilder.rootPluginConfig("""id("io.ia.sdk.modl") version("0.4.0-SNAPSHOT")""")
         }
 
         val config = configBuilder.build()

--- a/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/GeneratorConfig.kt
+++ b/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/GeneratorConfig.kt
@@ -116,7 +116,7 @@ data class GeneratorConfig constructor(
      * generated, as it is assumed the plugin will be established via 'includeBuild' in settings.gradle
      * pluginManagement.
      */
-    val modulePluginVersion: String = "0.2.0",
+    val modulePluginVersion: String = "0.4.0-SNAPSHOT",
 
     /**
      * If signing the module should be required, set to false.  Set to true by default to allow building the

--- a/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/GeneratorConfigBuilder.kt
+++ b/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/GeneratorConfigBuilder.kt
@@ -26,7 +26,7 @@ class GeneratorConfigBuilder {
     private var debugPluginConfig: Boolean = false
     private var rootPluginConfig: String = ""
     private var useRootForSingleProjectScope: Boolean = false
-    private var modulePluginVersion: String = "0.1.1"
+    private var modulePluginVersion: String = "0.4.0-SNAPSHOT"
     private var allowUnsignedModules: Boolean = false
 
     // builder methods

--- a/gradle-module-plugin/README.md
+++ b/gradle-module-plugin/README.md
@@ -19,7 +19,7 @@ For current versions of gradle, simply add to your `build.gradle.kts`:
 ```kotlin
 // build.gradle.kts
 plugins {
-  id("io.ia.sdk.modl") version("0.1.1")
+  id("io.ia.sdk.modl") version("0.4.0-SNAPSHOT")
 }
 ```
 
@@ -28,7 +28,7 @@ Or for Groovy DSL buildscripts:
 ```groovy
 // build.gradle
 plugins {
-    id 'io.ia.sdk.modl' version '0.1.1'
+    id 'io.ia.sdk.modl' version '0.4.0-SNAPSHOT'
 }
 ```
 

--- a/gradle-module-plugin/build.gradle.kts
+++ b/gradle-module-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 group = "io.ia.sdk"
-version = "0.3.0"
+version = "0.4.0-SNAPSHOT"
 
 configurations {
     val functionalTestImplementation by registering {


### PR DESCRIPTION
### Background
We're trying to do four things with this PR:

* Adding more structure around development windows by setting up explicitly for the next releases of generator and module plugin subprojects.
* Correct outdated non-build version references, especially version references from generator code to the module plugin. (See e.g. #49, which is likely caused by stale plugin version references.)
* Identify all such references in the sources as a guide for future releases. And perhaps some day automated update by, e.g., Gradle tasks and/or GitHub release workflows.
* Sync versioning across all projects contained in this monorepo.

### Changes
Prepare for upcoming releases of both generator and plugin.

* Generator core and CLI: `0.1.0-SNAPSHOT` > `0.4.0-SNAPSHOT`.
* Module plugin: `0.3.0` > `0.4.0-SNAPSHOT`.

Generator currently only scoped for bug fixes, but syncing its version with that of the module plugin for ease of maintenance. Module plugin has bug fixes and an improvement, hence the minor version bump.

`generator` and `gradle-module-plugin` are included builds, not subprojects, so there's not an easy way to just set a single version from the root build script.

With fixes for dangling old version strings throughout, especially for generator sources referencing the module plugin version.

These will become `0.4.0` before we release.

### Reviewer Notes
Artifacts for these `-SNAPSHOT` versions may or may not be published. In that sense they may break the `generator-core` and `generator-cli` subprojects. Generating publically-available snapshot artifacts is not the goal of this PR.