### PR TITLE
Support lazy evaluation of signed module output file

### DIFF
--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/SignModule.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/SignModule.kt
@@ -59,10 +59,10 @@ open class SignModule @Inject constructor(_providers: ProviderFactory, _objects:
 
     // the signed modl file
     @get:OutputFile
-    val signed: Provider<RegularFile> = unsigned.map {
+    val signed: Provider<RegularFile> = unsigned.flatMap {
         val unsignedFileName = it.asFile.name
         val signedName = unsignedFileName.replace(".unsigned", "")
-        project.layout.buildDirectory.file(signedName).get()
+        project.layout.buildDirectory.file(signedName)
     }
 
     @get:Input


### PR DESCRIPTION
This change converts .map/.get to .flatMap to allow for lazier evaluation of the signed module output file.

Redo of PR https://github.com/inductiveautomation/ignition-module-tools/pull/51 with clean history.