### PR TITLE
Add DuplicatesStrategy to sync task in CollectModlDependencies 

### DIFF
--- a/gradle-module-plugin/Contributing.md
+++ b/gradle-module-plugin/Contributing.md
@@ -10,8 +10,8 @@ change you wish to make with the project maintainers via issue or the IA forums.
 
 1. Ensure any local files or dependencies are removed before pushing
 2. Verify that new functionality is supported through new test cases when applicable
-2. Update the README.md with details of changes to tasks, interfaces or behavior, including new environment 
+3. Update the README.md with details of changes to tasks, interfaces or behavior, including new environment 
    variables, properties, useful file locations, etc.
-3. Make sure that the changes in the PR conform to the code formatting by running `./gradlew check` in the appropriate project
+4. Make sure that the changes in the PR conform to the code formatting by running `./gradlew check` in the appropriate project
 
 

--- a/gradle-module-plugin/build.gradle.kts
+++ b/gradle-module-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 group = "io.ia.sdk"
-version = "0.4.0"
+version = "0.4.1-SNAPSHOT"
 
 configurations {
     val functionalTestImplementation by registering {

--- a/gradle-module-plugin/build.gradle.kts
+++ b/gradle-module-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 group = "io.ia.sdk"
-version = "0.4.1-SNAPSHOT"
+version = "0.4.1"
 
 configurations {
     val functionalTestImplementation by registering {

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/CollectModlDependencies.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/CollectModlDependencies.kt
@@ -13,6 +13,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFile
 import org.gradle.api.model.ObjectFactory
@@ -142,6 +143,7 @@ open class CollectModlDependencies @Inject constructor(objects: ObjectFactory, l
         project.sync { copySpec ->
             copySpec.from(artifacts.map { it.jarFile })
             copySpec.into(artifactOutputDir.get())
+            copySpec.duplicatesStrategy = DuplicatesStrategy.WARN
         }
     }
 }


### PR DESCRIPTION
Grade requires this on collisions. Adding this will warn on the build about the collision but not prevent it. this was allowed in previous gradle versions.