### PR TITLE
Fail ignition build when duplicate lib jar with multiple versions detected in the module build result

### DIFF
--- a/gradle-module-plugin/build.gradle.kts
+++ b/gradle-module-plugin/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.kotlinXmlBuilder)
     api(libs.moduleSigner)
     testImplementation(libs.kotlinTestJunit)
+    testImplementation(libs.junit.jupiter.api)
     testImplementation("io.ia.sdk.tools.module.gen:generator-core")
 }
 

--- a/gradle-module-plugin/gradle/libs.versions.toml
+++ b/gradle-module-plugin/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "1.7.10"
 moshi = "1.9.3"
+junit-jupiter = "5.11.4"
 
 [libraries]
 # Dependencies referencable in buildscripts.  Note that dashes are replaced by periods in the buildscript reference.
@@ -8,6 +9,7 @@ guava = { module = "com.google.guava:guava", version = "30.1.1-jre" }
 kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinTestJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinXmlBuilder = { module = "org.redundent:kotlin-xml-builder", version = "1.7.2" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 moshi = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 moshiCodegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 moduleSigner = { module = "com.inductiveautomation.ignitionsdk:module-signer", version = "0.0.1.ia" }

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/ZipModuleTests.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/ZipModuleTests.kt
@@ -3,10 +3,61 @@ package io.ia.sdk.gradle.modl.task
 import io.ia.ignition.module.generator.ModuleGenerator
 import io.ia.sdk.gradle.modl.BaseTest
 import io.ia.sdk.gradle.modl.util.unsignedModuleName
-import org.junit.Test
-import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.api.internal.project.DefaultProject
+import org.gradle.api.tasks.TaskExecutionException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 
 class ZipModuleTests : BaseTest() {
+
+    @TempDir
+    lateinit var testProjectDir: File
+    private lateinit var project: Project
+    private lateinit var task: ZipModule
+
+    @BeforeEach
+    fun setup() {
+        project = ProjectBuilder.builder().withProjectDir(testProjectDir).build() as DefaultProject
+        task = project.tasks.create("testTask", ZipModule::class.java)
+
+        // Set up the task properties with the test directory
+        task.content.set(project.objects.directoryProperty().fileValue(File(testProjectDir, "content")))
+        task.unsignedModule.set(project.objects.fileProperty().fileValue(File(testProjectDir, "output.modl")))
+    }
+
+    @Test
+    fun `task succeeds when no duplicate jars exist`() {
+        // Arrange
+        val contentDir = File(testProjectDir, "content").apply { mkdirs() }
+        File(contentDir, "my-lib-1.0.jar").createNewFile()
+        File(contentDir, "another-lib-2.0.jar").createNewFile()
+
+        // Act & Assert: The task should not throw an exception
+        task.execute()
+    }
+
+    @Test
+    fun `task fails when duplicate jars with different versions exist`() {
+        // Arrange
+        val contentDir = File(testProjectDir, "content").apply { mkdirs() }
+        File(contentDir, "my-lib-1.0.jar").createNewFile()
+        File(contentDir, "my-lib-2.0.jar").createNewFile() // This is the duplicate
+
+        // Act & Assert: The task should throw a TaskExecutionException
+        val exception = assertThrows(TaskExecutionException::class.java) {
+            task.execute()
+        }
+
+        // Verify the exception message
+        val expectedMessage = "Jar with 'my-lib' has multiple versions presented"
+        assertTrue(exception.message!!.contains(expectedMessage))
+    }
 
     @Test
     fun `unsigned module is built and has appropriate name`() {

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ZipModule.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ZipModule.kt
@@ -13,6 +13,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskExecutionException
 import javax.inject.Inject
 
 /**
@@ -45,6 +46,35 @@ open class ZipModule @Inject constructor(objects: ObjectFactory) : DefaultTask()
     fun execute() {
         val unsignedFile = unsignedModule.get()
         val contentDir = content.get().asFile
+
+        project.logger.info("Parsing file name in: ${contentDir.absolutePath}")
+
+        val fileMap = mutableMapOf<String, String>()
+        val regex = "^(.+?)-(\\d+.*)(?:\\.jar)".toRegex()
+
+        // Try to detect jars with the same name but have multiple versions
+        // presented in the contentDir.  Fail the build when it's found.
+        contentDir.walk().filter { it.isFile }.forEach { file ->
+            val matchResult = regex.find(file.name) // Match all the jar files
+
+            if (matchResult != null) {
+                val name = matchResult.groupValues[1]
+                val version = matchResult.groupValues[2]
+
+                if (fileMap.containsKey(name)) {
+                    throw TaskExecutionException(
+                        this,
+                        IllegalArgumentException(
+                            """Jar with '$name' has multiple versions presented in ${contentDir.absolutePath}
+                            Please ensure only one version exist (preferably the highest) and update lib.version.toml file if needed.
+                            """.trimIndent()
+                        )
+                    )
+                } else {
+                    fileMap[name] = version
+                }
+            }
+        }
 
         project.logger.info("Zipping '${contentDir.absolutePath}' into ' ${unsignedFile.asFile.absolutePath}'")
         project.ant.invokeMethod(


### PR DESCRIPTION
### Background
Same jar name with more than one version were found in the module build result of some project.  Although I was not able to reproduce the problem, in theory this could happen due to the way we collect all dependencies for each module.   Please refer to the Updated Analysis section in the ticket below for more detailed investigations.

### Changes
Added the checking of the moduleContent before it gets zipped into the '.modl' file.  Fail the ignition build if the same jar with multiple versions presented in the same place.  

### QA test
Added some unit tests to verify the logic.  
  

Fixes: IGN-10168