### PR TITLE
Fail ignition build when the same jar in moduleContent folder with multiple versions detected

### DIFF
--- a/gradle-module-plugin/build.gradle.kts
+++ b/gradle-module-plugin/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.kotlinXmlBuilder)
     api(libs.moduleSigner)
     testImplementation(libs.kotlinTestJunit)
+    testImplementation(libs.junit.jupiter.api)
     testImplementation("io.ia.sdk.tools.module.gen:generator-core")
 }
 

--- a/gradle-module-plugin/build.gradle.kts
+++ b/gradle-module-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 group = "io.ia.sdk"
-version = "0.4.1"
+version = "0.5.0-SNAPSHOT"
 
 configurations {
     val functionalTestImplementation by registering {
@@ -61,7 +61,6 @@ dependencies {
     implementation(libs.kotlinXmlBuilder)
     api(libs.moduleSigner)
     testImplementation(libs.kotlinTestJunit)
-    testImplementation(libs.junit.jupiter.api)
     testImplementation("io.ia.sdk.tools.module.gen:generator-core")
 }
 

--- a/gradle-module-plugin/build.gradle.kts
+++ b/gradle-module-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 group = "io.ia.sdk"
-version = "0.5.0-SNAPSHOT"
+version = "0.5.0"
 
 configurations {
     val functionalTestImplementation by registering {

--- a/gradle-module-plugin/gradle/libs.versions.toml
+++ b/gradle-module-plugin/gradle/libs.versions.toml
@@ -1,7 +1,6 @@
 [versions]
 kotlin = "1.7.10"
 moshi = "1.9.3"
-junit-jupiter = "5.11.4"
 
 [libraries]
 # Dependencies referencable in buildscripts.  Note that dashes are replaced by periods in the buildscript reference.
@@ -9,7 +8,6 @@ guava = { module = "com.google.guava:guava", version = "30.1.1-jre" }
 kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinTestJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinXmlBuilder = { module = "org.redundent:kotlin-xml-builder", version = "1.7.2" }
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 moshi = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 moshiCodegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 moduleSigner = { module = "com.inductiveautomation.ignitionsdk:module-signer", version = "0.0.1.ia" }

--- a/gradle-module-plugin/gradle/libs.versions.toml
+++ b/gradle-module-plugin/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "1.7.10"
 moshi = "1.9.3"
+junit-jupiter = "5.11.4"
 
 [libraries]
 # Dependencies referencable in buildscripts.  Note that dashes are replaced by periods in the buildscript reference.
@@ -8,6 +9,7 @@ guava = { module = "com.google.guava:guava", version = "30.1.1-jre" }
 kotlinTest = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlinTestJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinXmlBuilder = { module = "org.redundent:kotlin-xml-builder", version = "1.7.2" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
 moshi = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 moshiCodegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
 moduleSigner = { module = "com.inductiveautomation.ignitionsdk:module-signer", version = "0.0.1.ia" }

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/ZipModuleTests.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/ZipModuleTests.kt
@@ -7,55 +7,61 @@ import org.gradle.api.Project
 import org.gradle.api.internal.project.DefaultProject
 import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.testfixtures.ProjectBuilder
-import org.junit.jupiter.api.Assertions.assertThrows
-import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.TempDir
+import kotlin.io.path.createTempDirectory
+import kotlin.test.BeforeTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 import java.io.File
 
 class ZipModuleTests : BaseTest() {
 
-    @TempDir
-    lateinit var testProjectDir: File
+    private lateinit var tempDir: File
     private lateinit var project: Project
     private lateinit var task: ZipModule
 
-    @BeforeEach
+    @BeforeTest
     fun setup() {
-        project = ProjectBuilder.builder().withProjectDir(testProjectDir).build() as DefaultProject
+        tempDir = createTempDirectory().toFile()
+        project = ProjectBuilder.builder().withProjectDir(tempDir).build() as DefaultProject
         task = project.tasks.create("testTask", ZipModule::class.java)
 
-        // Set up the task properties with the test directory
-        task.content.set(project.objects.directoryProperty().fileValue(File(testProjectDir, "content")))
-        task.unsignedModule.set(project.objects.fileProperty().fileValue(File(testProjectDir, "output.modl")))
+        // Set up the task properties with the temp directory
+        task.content.set(project.objects.directoryProperty().fileValue(File(tempDir, "content")))
+        task.unsignedModule.set(project.objects.fileProperty().fileValue(File(tempDir, "output.modl")))
+    }
+
+    @AfterTest
+    fun cleanup() {
+        tempDir.deleteRecursively()
     }
 
     @Test
     fun `task succeeds when no duplicate jars exist`() {
         // Arrange
-        val contentDir = File(testProjectDir, "content").apply { mkdirs() }
+        val contentDir = task.content.asFile.get().apply { mkdirs() }
         File(contentDir, "my-lib-1.0.jar").createNewFile()
         File(contentDir, "another-lib-2.0.jar").createNewFile()
 
-        // Act & Assert: The task should not throw an exception
+        // Act: The task should not throw an exception
         task.execute()
     }
 
     @Test
     fun `task fails when duplicate jars with different versions exist`() {
         // Arrange
-        val contentDir = File(testProjectDir, "content").apply { mkdirs() }
+        val contentDir = task.content.asFile.get().apply { mkdirs() }
         File(contentDir, "my-lib-1.0.jar").createNewFile()
         File(contentDir, "my-lib-2.0.jar").createNewFile() // This is the duplicate
 
-        // Act & Assert: The task should throw a TaskExecutionException
-        val exception = assertThrows(TaskExecutionException::class.java) {
+        // Act & Assert: The task should throw a IllegalArgumentException
+        val exception = assertFailsWith<IllegalArgumentException>{
             task.execute()
         }
 
         // Verify the exception message
-        val expectedMessage = "Jar with 'my-lib' has multiple versions presented"
+        val expectedMessage = "Library 'my-lib' exists in multiple versions"
         assertTrue(exception.message!!.contains(expectedMessage))
     }
 

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/ZipModuleTests.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/ZipModuleTests.kt
@@ -3,10 +3,61 @@ package io.ia.sdk.gradle.modl.task
 import io.ia.ignition.module.generator.ModuleGenerator
 import io.ia.sdk.gradle.modl.BaseTest
 import io.ia.sdk.gradle.modl.util.unsignedModuleName
-import org.junit.Test
-import kotlin.test.assertTrue
+import org.gradle.api.Project
+import org.gradle.api.internal.project.DefaultProject
+import org.gradle.api.tasks.TaskExecutionException
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
 
 class ZipModuleTests : BaseTest() {
+
+    @TempDir
+    lateinit var testProjectDir: File
+    private lateinit var project: Project
+    private lateinit var task: ZipModule
+
+    @BeforeEach
+    fun setup() {
+        project = ProjectBuilder.builder().withProjectDir(testProjectDir).build() as DefaultProject
+        task = project.tasks.create("testTask", ZipModule::class.java)
+
+        // Set up the task properties with the test directory
+        task.content.set(project.objects.directoryProperty().fileValue(File(testProjectDir, "content")))
+        task.unsignedModule.set(project.objects.fileProperty().fileValue(File(testProjectDir, "output.modl")))
+    }
+
+    @Test
+    fun `task succeeds when no duplicate jars exist`() {
+        // Arrange
+        val contentDir = File(testProjectDir, "content").apply { mkdirs() }
+        File(contentDir, "my-lib-1.0.jar").createNewFile()
+        File(contentDir, "another-lib-2.0.jar").createNewFile()
+
+        // Act & Assert: The task should not throw an exception
+        task.execute()
+    }
+
+    @Test
+    fun `task fails when duplicate jars with different versions exist`() {
+        // Arrange
+        val contentDir = File(testProjectDir, "content").apply { mkdirs() }
+        File(contentDir, "my-lib-1.0.jar").createNewFile()
+        File(contentDir, "my-lib-2.0.jar").createNewFile() // This is the duplicate
+
+        // Act & Assert: The task should throw a TaskExecutionException
+        val exception = assertThrows(TaskExecutionException::class.java) {
+            task.execute()
+        }
+
+        // Verify the exception message
+        val expectedMessage = "Jar with 'my-lib' has multiple versions presented"
+        assertTrue(exception.message!!.contains(expectedMessage))
+    }
 
     @Test
     fun `unsigned module is built and has appropriate name`() {

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/ZipModuleTests.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/ZipModuleTests.kt
@@ -5,7 +5,6 @@ import io.ia.sdk.gradle.modl.BaseTest
 import io.ia.sdk.gradle.modl.util.unsignedModuleName
 import org.gradle.api.Project
 import org.gradle.api.internal.project.DefaultProject
-import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.testfixtures.ProjectBuilder
 import kotlin.io.path.createTempDirectory
 import kotlin.test.BeforeTest

--- a/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/ZipModuleTests.kt
+++ b/gradle-module-plugin/src/functionalTest/kotlin/io/ia/sdk/gradle/modl/task/ZipModuleTests.kt
@@ -6,13 +6,13 @@ import io.ia.sdk.gradle.modl.util.unsignedModuleName
 import org.gradle.api.Project
 import org.gradle.api.internal.project.DefaultProject
 import org.gradle.testfixtures.ProjectBuilder
-import kotlin.io.path.createTempDirectory
-import kotlin.test.BeforeTest
-import kotlin.test.AfterTest
-import kotlin.test.Test
-import kotlin.test.assertTrue
-import kotlin.test.assertFailsWith
 import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class ZipModuleTests : BaseTest() {
 
@@ -55,7 +55,7 @@ class ZipModuleTests : BaseTest() {
         File(contentDir, "my-lib-2.0.jar").createNewFile() // This is the duplicate
 
         // Act & Assert: The task should throw a IllegalArgumentException
-        val exception = assertFailsWith<IllegalArgumentException>{
+        val exception = assertFailsWith<IllegalArgumentException> {
             task.execute()
         }
 

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ZipModule.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ZipModule.kt
@@ -58,33 +58,26 @@ open class ZipModule @Inject constructor(objects: ObjectFactory) : DefaultTask()
     }
 
     /**
-     * Try to detect jars in contentDir with the same name but have multiple
-     * versions existed.  Fail the build when it's found.
+     * Fail the build when jars in the contentDir with the same name has
+     * multiple versions detected.
      **/
     fun checkDuplicateJars(contentDir: File) {
         project.logger.info("Parsing file name in: ${contentDir.absolutePath}")
 
-        val fileMap = mutableMapOf<String, String>()
-        val regex = "^(.+?)-(\\d+.*)(?:\\.jar)".toRegex()
+        val fileSet = mutableSetOf<String>()
+        val regex = "^(.+?)-(?:\\d+.*)(?:\\.jar)".toRegex()
 
         contentDir.walk().filter { it.isFile }.forEach { file ->
             val matchResult = regex.find(file.name) // Match all the jar files
 
             if (matchResult != null) {
                 val name = matchResult.groupValues[1]
-                val version = matchResult.groupValues[2]
 
-                if (fileMap.containsKey(name)) {
-                    throw TaskExecutionException(
-                        this,
-                        IllegalArgumentException(
-                            """Jar with '$name' has multiple versions presented in ${contentDir.absolutePath}
-                            Please ensure only one version exist (preferably the highest) and update lib.version.toml file if needed.
-                            """.trimIndent()
-                        )
-                    )
+                if (fileSet.contains(name)) {
+                    throw IllegalArgumentException(
+                            "Library '$name' exists in multiple versions in ${contentDir.absolutePath}")
                 } else {
-                    fileMap[name] = version
+                    fileSet.add(name)
                 }
             }
         }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ZipModule.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ZipModule.kt
@@ -74,7 +74,8 @@ open class ZipModule @Inject constructor(objects: ObjectFactory) : DefaultTask()
 
                 if (fileSet.contains(name)) {
                     throw IllegalArgumentException(
-                            "Library '$name' exists in multiple versions in ${contentDir.absolutePath}")
+                        "Library '$name' exists in multiple versions in ${contentDir.absolutePath}"
+                    )
                 } else {
                     fileSet.add(name)
                 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ZipModule.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ZipModule.kt
@@ -13,6 +13,8 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskExecutionException
+import java.io.File
 import javax.inject.Inject
 
 /**
@@ -46,10 +48,45 @@ open class ZipModule @Inject constructor(objects: ObjectFactory) : DefaultTask()
         val unsignedFile = unsignedModule.get()
         val contentDir = content.get().asFile
 
+        checkDuplicateJars(contentDir)
+
         project.logger.info("Zipping '${contentDir.absolutePath}' into ' ${unsignedFile.asFile.absolutePath}'")
         project.ant.invokeMethod(
             "zip",
             mapOf("basedir" to contentDir, "destfile" to unsignedFile)
         )
+    }
+
+    /**
+     * Try to detect jars in contentDir with the same name but have multiple
+     * versions existed.  Fail the build when it's found.
+     **/
+    fun checkDuplicateJars(contentDir: File) {
+        project.logger.info("Parsing file name in: ${contentDir.absolutePath}")
+
+        val fileMap = mutableMapOf<String, String>()
+        val regex = "^(.+?)-(\\d+.*)(?:\\.jar)".toRegex()
+
+        contentDir.walk().filter { it.isFile }.forEach { file ->
+            val matchResult = regex.find(file.name) // Match all the jar files
+
+            if (matchResult != null) {
+                val name = matchResult.groupValues[1]
+                val version = matchResult.groupValues[2]
+
+                if (fileMap.containsKey(name)) {
+                    throw TaskExecutionException(
+                        this,
+                        IllegalArgumentException(
+                            """Jar with '$name' has multiple versions presented in ${contentDir.absolutePath}
+                            Please ensure only one version exist (preferably the highest) and update lib.version.toml file if needed.
+                            """.trimIndent()
+                        )
+                    )
+                } else {
+                    fileMap[name] = version
+                }
+            }
+        }
     }
 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ZipModule.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/ZipModule.kt
@@ -13,7 +13,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.TaskExecutionException
 import java.io.File
 import javax.inject.Inject
 


### PR DESCRIPTION
### Background
Same jar name with more than one version were found in the module build result of some project. Although I was not able to reproduce the problem, in theory this could happen due to the way we collect all dependencies for each module. Please refer to the Updated Analysis section in the ticket below for more detailed investigations.

### Changes
Added the checking of the moduleContent before it gets zipped into the '.modl' file. Fail the ignition build if the same jar with multiple versions presented in the same place.

### QA test
Added some unit tests to verify the logic.  Inspired by Brian's testing, I have made following set up and did my due-diligence:

In ignition repo:
1. Updated root build.gradle.kts with the following (Have published io.ia.sdk.modl.0.5.0-SNAPSHOT to my local maven):
`    id("io.ia.sdk.modl") version "0.5.0-SNAPSHOT" apply false`

2. Updated opc-ua-client/build.gradle.kts with the following (The netty version specified in lib.tooling.toml is 4.1.121.Final):
`dependencies {`
`    ...`
`    modlApi("io.netty:netty-buffer:4.1.109.Final")`
`    modlApi("io.netty:netty-codec:4.1.109.Final")`
`    modlApi("io.netty:netty-handler:4.1.109.Final")`
`}`

4. Run task ':Modules:opc-ua:zipModule' in the root project.  And I'm getting the following error as expected:
`
> Task :Modules:opc-ua:zipModule FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':Modules:opc-ua:zipModule'.
> Library 'netty-resolver' exits in multiple versions in /Users/vzhang/workspace/ignition/release/8.3.0/Modules/opc-ua/build/moduleContent
`
5. Examined the moduleContent directory, and I'm getting the following as expected:
`vzhang@DV-vzhang-MBP 8.3.0 % ls Modules/opc-ua/build/moduleContent | grep netty`
`netty-buffer-4.1.109.Final.jar`
`netty-buffer-4.1.121.Final.jar`
`netty-channel-fsm-1.0.1.jar`
`netty-codec-4.1.109.Final.jar`
`netty-codec-4.1.121.Final.jar`
`netty-common-4.1.109.Final.jar`
`netty-common-4.1.121.Final.jar`
`netty-handler-4.1.109.Final.jar`
`netty-handler-4.1.121.Final.jar`
`netty-resolver-4.1.109.Final.jar`
`netty-resolver-4.1.121.Final.jar`
`netty-transport-4.1.109.Final.jar`
`netty-transport-4.1.121.Final.jar`
`netty-transport-native-unix-common-4.1.109.Final.jar`
`netty-transport-native-unix-common-4.1.121.Final.jar`

Fixes: IGN-10168