### PR TITLE
Switch publish branch to 8.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - "8.3"
 
 jobs:
   build:


### PR DESCRIPTION
Currently it's using master branch for publishing.  This has prevented breaking change merging into the master.  Switch to use 8.3 instead.

Fixes: IGN-15978