### PR TITLE
Change release branch to 8.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - "8.3"
 
 jobs:
   build:


### PR DESCRIPTION
In 8.3 branch, the push to trigger branch of Github release workflow is still pointing to master branch, which should be 8.3 instead.  With this change, we can keep making non-breaking changes and publish them to the public repo using 8.3.

Fixes: IGN-15978