### PR TITLE
Change release branch to 8.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,16 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: Release
-#  if: github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - "8.3"
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Gradle Module Plugin Build Task
         working-directory: ./gradle-module-plugin
         run: ./gradlew build --stacktrace --info
-#      - name: Publish Plugins
-#        working-directory: ./gradle-module-plugin
-#        run: ./gradlew publishPlugins -Pgradle.publish.key=${{secrets.PLUGIN_PUBLISHING_KEY}} -Pgradle.publish.secret=${{secrets.PLUGIN_PUBLISHING_SECRET}}
+      - name: Publish Plugins
+        working-directory: ./gradle-module-plugin
+        run: ./gradlew publishPlugins -Pgradle.publish.key=${{secrets.PLUGIN_PUBLISHING_KEY}} -Pgradle.publish.secret=${{secrets.PLUGIN_PUBLISHING_SECRET}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - "8.3"
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,6 @@ jobs:
       - name: Gradle Module Plugin Build Task
         working-directory: ./gradle-module-plugin
         run: ./gradlew build --stacktrace --info
-      - name: Publish Plugins
-        working-directory: ./gradle-module-plugin
-        run: ./gradlew publishPlugins -Pgradle.publish.key=${{secrets.PLUGIN_PUBLISHING_KEY}} -Pgradle.publish.secret=${{secrets.PLUGIN_PUBLISHING_SECRET}}
+#      - name: Publish Plugins
+#        working-directory: ./gradle-module-plugin
+#        run: ./gradlew publishPlugins -Pgradle.publish.key=${{secrets.PLUGIN_PUBLISHING_KEY}} -Pgradle.publish.secret=${{secrets.PLUGIN_PUBLISHING_SECRET}}


### PR DESCRIPTION
The release workflow trigger branch should be 8.3 instead of master on master branch.  With this change, the publish task will not be triggered after push commit on master branch.

Fixes: IGN-15978