### PR TITLE
Fix module classloader IDE problem for gateway

### DIFF
--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 allprojects {
-    project.version = "1.0.0"
+    project.version = "1.1.0"
 }
 
 tasks {

--- a/generator/generator-cli/src/main/kotlin/io/ia/sdk/tools/module/cli/ModuleGeneratorCli.kt
+++ b/generator/generator-cli/src/main/kotlin/io/ia/sdk/tools/module/cli/ModuleGeneratorCli.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.Callable
 
 @Command(
     name = "ignition-module-gen",
-    version = ["1.0.0"],
+    version = ["1.1.0"],
     description = ["Generates an Ignition module skeleton according to provided arguments."],
     subcommands = [HelpCommand::class],
     mixinStandardHelpOptions = true,
@@ -158,7 +158,7 @@ class ModuleGeneratorCli : Callable<Int> {
             configBuilder.debugPluginConfig(true)
             configBuilder.rootPluginConfig("""id("io.ia.sdk.modl")""")
         } else {
-            configBuilder.rootPluginConfig("""id("io.ia.sdk.modl") version("1.0.0")""")
+            configBuilder.rootPluginConfig("""id("io.ia.sdk.modl") version("1.1.0")""")
         }
 
         val config = configBuilder.build()

--- a/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/GeneratorConfig.kt
+++ b/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/GeneratorConfig.kt
@@ -116,7 +116,7 @@ data class GeneratorConfig constructor(
      * generated, as it is assumed the plugin will be established via 'includeBuild' in settings.gradle
      * pluginManagement.
      */
-    val modulePluginVersion: String = "1.0.0",
+    val modulePluginVersion: String = "1.1.0",
 
     /**
      * If signing the module should be required, set to false.  Set to true by default to allow building the

--- a/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/GeneratorConfigBuilder.kt
+++ b/generator/generator-core/src/main/kotlin/io/ia/ignition/module/generator/api/GeneratorConfigBuilder.kt
@@ -26,7 +26,7 @@ class GeneratorConfigBuilder {
     private var debugPluginConfig: Boolean = false
     private var rootPluginConfig: String = ""
     private var useRootForSingleProjectScope: Boolean = false
-    private var modulePluginVersion: String = "1.0.0"
+    private var modulePluginVersion: String = "1.1.0"
     private var allowUnsignedModules: Boolean = false
 
     // builder methods

--- a/gradle-module-plugin/README.md
+++ b/gradle-module-plugin/README.md
@@ -4,8 +4,6 @@ The Ignition platform is an open/pluggable JVM based system that uses Ignition M
 
 The Ignition Module Plugin for Gradle lets module developers use the [Gradle](https://www.gradle.org) build tool to create and sign functional modules (_.modl_ ) through a convenient DSL-based configuration model.
 
-
-
 ## Usage
 
 The easiest way to get started with this plugin is to create a new module project using the Ignition Module Generator in this repository.
@@ -19,7 +17,7 @@ For current versions of gradle, simply add to your `build.gradle.kts`:
 ```kotlin
 // build.gradle.kts
 plugins {
-  id("io.ia.sdk.modl") version("1.0.0")
+  id("io.ia.sdk.modl") version("1.1.0")
 }
 ```
 
@@ -28,43 +26,40 @@ Or for Groovy DSL buildscripts:
 ```groovy
 // build.gradle
 plugins {
-    id 'io.ia.sdk.modl' version '1.0.0'
+    id 'io.ia.sdk.modl' version '1.1.0'
 }
 ```
 
 2. Configure your module through the `ignitionModule` configuration DSL. See DSL properties section below for details.
-
 3. Configure your signing settings, either in a gradle.properties file, or as commandline flags. The required properties are defined in `Constants.kt`, and used in the `SignModule` task. You may mix and match flags and properties (and flags will override properties), as long as all required values are configured. The only requirement is that option flags _must_ follow the Gradle task to which they apply, which is `signModule`. The `keystoreFile` and `pkcs11CfgFile` settings are mutually exclusive, the former indicating a file-based keystore and the latter indicating the config file for a PKCS#11 HSM (such as a YubiKey) keystore. Use one or the other but not both. All flags/properties are as follows, with usage examples:
 
-   | Flag  | Usage                                                  | gradle.properties entry                            |
-   |-------|--------------------------------------------------------|----------------------------------------------------|
-   | certAlias  | gradlew signModule --certAlias=someAlias               | ignition.signing.certAlias=someAlias               |
-   | certFile  | gradlew signModule --certFile=/path/to/cert            | ignition.signing.certFile=/path/to/cert            |
-   | certPassword  | gradlew signModule --certPassword=certPwdOrPIN         | ignition.signing.certPassword=certPwdOrPIN         |
-   | keystoreFile  | gradlew signModule --keystoreFile=/path/to/keystore    | ignition.signing.keystoreFile=/path/to/keystore    |
-   | pkcs11CfgFile  | gradlew signModule --pkcs11CfgFile=/path/to/pkcs11.cfg | ignition.signing.pkcs11CfgFile=/path/to/pkcs11.cfg |
-   | keystorePassword  | gradlew signModule --keystorePassword=ksPwdOrPIN       | ignition.signing.keystorePassword=ksPwdOrPIN       | 
 
+   | Flag             | Usage                                                  | gradle.properties entry                            |
+   | ---------------- | ------------------------------------------------------ | -------------------------------------------------- |
+   | certAlias        | gradlew signModule --certAlias=someAlias               | ignition.signing.certAlias=someAlias               |
+   | certFile         | gradlew signModule --certFile=/path/to/cert            | ignition.signing.certFile=/path/to/cert            |
+   | certPassword     | gradlew signModule --certPassword=certPwdOrPIN         | ignition.signing.certPassword=certPwdOrPIN         |
+   | keystoreFile     | gradlew signModule --keystoreFile=/path/to/keystore    | ignition.signing.keystoreFile=/path/to/keystore    |
+   | pkcs11CfgFile    | gradlew signModule --pkcs11CfgFile=/path/to/pkcs11.cfg | ignition.signing.pkcs11CfgFile=/path/to/pkcs11.cfg |
+   | keystorePassword | gradlew signModule --keystorePassword=ksPwdOrPIN       | ignition.signing.keystorePassword=ksPwdOrPIN       |
 4. When depending on artifacts (dependencies) from the Ignition SDK, they should be specified as `compileOnly` or `compileOnlyApi`  dependencies as they will be provided by the Ignition platform at runtime. Dependencies that are applied with either the `modlApi` or `modlImplementation` _Configuration_ in any subproject of your module will be collected and included in the final modl file, including transitive dependencies. In general, behaviors of the _modl_ configuration follow those documented by the Gradle java-library plugin (e.g. - publishing, artifact uploading, transitive dependency handling, etc). Test-only dependencies should NOT be marked with any `modl` configuration. Test and Compile-time dependencies should be specified in accordance with the best practices described in Gradle's `java-library` [plugin documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html).
-
 
 Choosing which [Configuration](https://docs.gradle.org/current/userguide/declaring_dependencies.html) to apply may have important but subtle impacts on your module, as well as your development/build environment. In general, the following rule of thumb is a good starting point:
 
-| Configuration  | Usage Suggestion | Included in Module? | Includes Transitive Dependencies In Module? | Exposes Transitive Dependencies to Artifact Consumers&#735;? |
-|-------|--------|-------------------------|----------|---------|
-| compileOnly   | Use for 'compile time only' dependencies, including ignition sdk dependencies. Similar to maven 'provided'. | No | No | No |
-| compileOnlyApi   | Use for 'compile time only' dependencies, including ignition sdk dependencies. Similar to maven 'provided'. | No | No | No |
-| api    | Project dependencies that do not explicitly get registered in the module DSL project scopes&#10013;  | No | No | Yes |
-| implementation   | Project dependencies that do not explicitly get registered in the module DSL project scopes&#10013; | No | No | No |
-| modlImplementation   | Dependencies that are used in a module project's implementation, but are not part of a public API  | Yes | Yes | No |
-| modlApi | Dependencies that are used in a module project and are exposed to dependents&#10013;&#10013;  | Yes | Yes | Yes |
+
+| Configuration      | Usage Suggestion                                                                                            | Included in Module? | Includes Transitive Dependencies In Module? | Exposes Transitive Dependencies to Artifact Consumers&#735;? |
+| ------------------ | ----------------------------------------------------------------------------------------------------------- | ------------------- | ------------------------------------------- | ------------------------------------------------------------ |
+| compileOnly        | Use for 'compile time only' dependencies, including ignition sdk dependencies. Similar to maven 'provided'. | No                  | No                                          | No                                                           |
+| compileOnlyApi     | Use for 'compile time only' dependencies, including ignition sdk dependencies. Similar to maven 'provided'. | No                  | No                                          | No                                                           |
+| api                | Project dependencies that do not explicitly get registered in the module DSL project scopes&#10013;         | No                  | No                                          | Yes                                                          |
+| implementation     | Project dependencies that do not explicitly get registered in the module DSL project scopes&#10013;         | No                  | No                                          | No                                                           |
+| modlImplementation | Dependencies that are used in a module project's implementation, but are not part of a public API           | Yes                 | Yes                                         | No                                                           |
+| modlApi            | Dependencies that are used in a module project and are exposed to dependents&#10013;&#10013;                | Yes                 | Yes                                         | Yes                                                          |
 
 > &#10013; - api and implementation configurations and generally best reserved for internal/intra-project dependencies. Meaning, if you have a module with projects A,B,C, and D, where A is only a supporting library for D (aka - it is not registered as a 'projectScope', but is merely a dependency of D), then `api` or `implementation` would be appropriate. Choose `api` if D exposes A as part of it's Application Binary Interface (ABI). Otherwise, choose `implementation` if A is only used internally for the implementation of D.<br>
 > &#10013;&#10013; - modlApi is a very uncommon use case, generally reserved only for modules which themselves expose an API that is to be extended by other modules. Examples of Inductive Automation modules that use this include Opc-Ua, which exposes an API for driver module implementations, or Perspective, which exposes an API for Component Authors through the SDK. If you do not support an SDK for your module, then you should probably use `modlImplementation`, as it will encourage better separation of concerns in your project.<br>
 > &#735; 'Artifact Consumers' refers to projects that may depend on ('consume') the library (aka - gradle subproject) you are writing, or if published to an artifact repo, consumers of the maven artifact. Dependencies that are not part of a project's ABI should avoid being specified with `modlApi` to avoid leaking implementation details into the compile-time classpath of the consuming project.<br><br>
 > **Maven Users**: If you're familiar with Maven's dependency scopes, you might initially find Gradle's handling of dependencies to be unnecessarily convoluted. This is a product of Gradle's powerful (but more complex) dependency management. We suggest reading the gradle docs on [Working With Dependencies](https://docs.gradle.org/current/userguide/core_dependency_management.html), followed by reading the [Java Library Plugin](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation) documentation.
-
-
 
 ### `ignitionModule` DSL Properties
 
@@ -243,10 +238,9 @@ ignitionModule {
 }
 ```
 
- # Tasks
+# Tasks
 
- > To see all tasks provided by the plugin, run the `tasks` gradle command, or `tasks --all` to see all possible tasks.
-
+> To see all tasks provided by the plugin, run the `tasks` gradle command, or `tasks --all` to see all possible tasks.
 
 The module plugin exposes a number of tasks that may be run on their own, and some which are bound to lifecycle tasks
 provided by Gradle's [Base Plugin](https://docs.gradle.org/current/userguide/base_plugin.html). Some tasks apply
@@ -254,21 +248,20 @@ only to the root project (the project which is applying the plugin), while other
 subprojects. The following table is a brief reference:
 
 
-| Task  | Scope  | Description |
-|-------|--------|-------------------------|
-| collectModlDependencies  | root and child projects  | Resolves and collects dependencies from projects with the `java-library` plugin that marked with 'modlApi/modlImplementation' configuration |
-| assembleModlStructure | aggregates assets, dependencies and assembled project jars created by the 'collectModlDependencies' task into the module staging directory |
-| writeModuleXml  | root project  | Writes the module.xml file to the staging directory  |
-| zipModule  | root project | Compresses the staged module contents into an unsigned zip archive with a .modl file extension  |
-| checksumModl  | root project  | Generates a checksum for the signed module, and writes the result to a json file  |
-| modlReport  | root project | Writes a json file containing meta information about the module's assembly  |
-| signModule | root project | signs the unsigned modl using credentials/certs noted above
+| Task                    | Scope                                                                                                                                      | Description                                                                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| collectModlDependencies | root and child projects                                                                                                                    | Resolves and collects dependencies from projects with the`java-library` plugin that marked with 'modlApi/modlImplementation' configuration |
+| assembleModlStructure   | aggregates assets, dependencies and assembled project jars created by the 'collectModlDependencies' task into the module staging directory |                                                                                                                                            |
+| writeModuleXml          | root project                                                                                                                               | Writes the module.xml file to the staging directory                                                                                        |
+| zipModule               | root project                                                                                                                               | Compresses the staged module contents into an unsigned zip archive with a .modl file extension                                             |
+| checksumModl            | root project                                                                                                                               | Generates a checksum for the signed module, and writes the result to a json file                                                           |
+| modlReport              | root project                                                                                                                               | Writes a json file containing meta information about the module's assembly                                                                 |
+| signModule              | root project                                                                                                                               | signs the unsigned modl using credentials/certs noted above                                                                                |
 
 > &#735; to enable the developer mode, add `-Dia.developer.moduleupload=true` to the 'Java Additional Parameters' in
 > the `ignition.conf` file and restart the gateway. **This should only be done on secure development gateways, as it
 > opens a significant security risk on production gateways, in addition to instabilities that may result from your
 > in-development module.**
-
 
 ## Task Configuration
 
@@ -284,7 +277,6 @@ in the project's dependency settings. In addition, it will create the asset coll
 assemble_ lifecycle tasks, and ultimately establish task dependencies for the 'root-specific' tasks that create the
 module xml, copy files into the appropriate structure, zip the folder into an unsigned modl file, sign it, and report
 the result.
-
 
 # IDE Development with Dev Module Descriptors
 
@@ -336,6 +328,7 @@ Then restart the gateway.
 6. Test in the browser — changes are live
 
 Repeat steps 4-6 without restarting. Only restart the gateway when:
+
 - Module dependencies change (added/removed/version bumped)
 - Module metadata changes (hooks, module dependencies)
 - Structural class changes that HotSwap can't handle (new methods, new fields)
@@ -349,12 +342,12 @@ Repeat steps 4-6 without restarting. Only restart the gateway when:
 ## Descriptor Format
 
 The descriptor is a JSON file containing:
+
 - Module metadata (id, name, version, hooks, dependencies)
 - Per-scope class output directories (includes `build/classes/java/main`, `build/classes/kotlin/main`, `build/resources/main`, and `out/production/classes` if IDEA output exists)
 - Per-scope third-party dependency JARs (from `build/artifacts/`, populated by `collectModlDependencies`)
 
 The gateway creates a `ModuleClassLoader` per module from these paths, achieving the same classloader isolation as production `.modl` loading.
-
 
 # Pre-Release API Changes
 

--- a/gradle-module-plugin/README.md
+++ b/gradle-module-plugin/README.md
@@ -286,6 +286,76 @@ module xml, copy files into the appropriate structure, zip the folder into an un
 the result.
 
 
+# IDE Development with Dev Module Descriptors
+
+The `writeDevModuleDescriptor` task generates a JSON descriptor that allows a dev Ignition gateway to load your module directly from Gradle build outputs — class directories and dependency JARs — instead of requiring a full `.modl` build. This provides:
+
+- **Classloader isolation** matching production behavior (each module gets its own `ModuleClassLoader`)
+- **HotSwap support** for method-body changes via JDWP
+- **No .modl build required** — no compile+zip+sign cycle for code changes
+
+## Gateway Configuration
+
+Your dev gateway needs these JVM flags in `ignition.conf` (or wrapper config):
+
+```
+# Required: allow unsigned modules (dev descriptors bypass module signing)
+-Dignition.allowunsignedmodules=true
+
+# Required: point gateway at dev descriptor directory
+-Dignition.dev.moduleDir=user-lib/modules/dev
+
+# Recommended: enable remote debugging for breakpoints + HotSwap
+-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+```
+
+> **Note:** These flags only activate on **dev builds** of Ignition (`isDev()` must return true). The dev module loading path is completely inert on production gateways.
+
+## Generating the Descriptor
+
+```bash
+./gradlew writeDevModuleDescriptor
+```
+
+This produces `build/dev/{moduleId}.json`. Copy this file to your gateway's `user-lib/modules/dev/` directory:
+
+```bash
+mkdir -p /path/to/ignition/user-lib/modules/dev
+cp build/dev/*.json /path/to/ignition/user-lib/modules/dev/
+```
+
+Then restart the gateway.
+
+## Development Workflow
+
+1. Run `./gradlew writeDevModuleDescriptor` and copy the descriptor (first time, or after dependency changes)
+2. Start/restart the gateway
+3. In IntelliJ: **Run → Attach to Process** (or create a **Remote JVM Debug** config on port 5005)
+4. Make code changes
+5. **Build → Recompile** (Ctrl+Shift+F9 / Cmd+Shift+F9) — HotSwap applies method-body changes immediately
+6. Test in the browser — changes are live
+
+Repeat steps 4-6 without restarting. Only restart the gateway when:
+- Module dependencies change (added/removed/version bumped)
+- Module metadata changes (hooks, module dependencies)
+- Structural class changes that HotSwap can't handle (new methods, new fields)
+
+## Prerequisites
+
+- The dev gateway must be running a **dev build** of Ignition
+- Your module must be compiled first (`./gradlew build` or IDEA compile)
+- The `build/artifacts/` directory must be populated by `collectModlDependencies` (runs as part of normal `build`)
+
+## Descriptor Format
+
+The descriptor is a JSON file containing:
+- Module metadata (id, name, version, hooks, dependencies)
+- Per-scope class output directories (includes `build/classes/java/main`, `build/classes/kotlin/main`, `build/resources/main`, and `out/production/classes` if IDEA output exists)
+- Per-scope third-party dependency JARs (from `build/artifacts/`, populated by `collectModlDependencies`)
+
+The gateway creates a `ModuleClassLoader` per module from these paths, achieving the same classloader isolation as production `.modl` loading.
+
+
 # Pre-Release API Changes
 
 * v0.1.0-SNAPSHOT-6 - changed how credentials and files are specified for signing and publication. The keys are the same, but properties are now expected to exist in a gradle.properties file, or to be specified as runtime flags as described in the Usage section above.

--- a/gradle-module-plugin/README.md
+++ b/gradle-module-plugin/README.md
@@ -1,3 +1,4 @@
+
 # Ignition Module Plugin for Gradle
 
 The Ignition platform is an open/pluggable JVM based system that uses Ignition Modules to add functionality. As documented in the [Ignition SDK Programmer's Guide](https://docs.inductiveautomation.com/display/SE/Ignition+SDK+Programmers+Guide), an Ignition Module consists of an xml manifest, jar files, and additional resources and meta-information.
@@ -286,6 +287,12 @@ The `writeDevModuleDescriptor` task generates a JSON descriptor that allows a de
 - **HotSwap support** for method-body changes via JDWP
 - **No .modl build required** — no compile+zip+sign cycle for code changes
 
+> **Multi-module semantics:** the task is registered once on the module-root project and emits a
+> single, aggregate descriptor for the whole module — not one descriptor per subproject. A layout
+> such as `parent + api + gateway + designer + client + common` still produces one
+> `build/dev/{moduleId}.json`, with each subproject's class dirs and jars grouped under the scope(s)
+> declared for it in `projectScopes`.
+
 ## Gateway Configuration
 
 Your dev gateway needs these JVM flags in `ignition.conf` (or wrapper config):
@@ -317,6 +324,14 @@ cp build/dev/*.json /path/to/ignition/user-lib/modules/dev/
 ```
 
 Then restart the gateway.
+
+> **Absolute paths are baked in:** the descriptor's `classDirs` and `jars` are absolute filesystem
+> paths from the machine that generated it. It is not portable — don't commit it or share it between
+> machines; regenerate it on each dev machine.
+
+> **Ignition monorepo devs:** the manual copy above is for third-party module authors. Within the
+> `ignition` repo itself the descriptors are collected automatically by the `collectDevDescriptors`
+> `Sync` task wired into the gateway run configuration, so you don't copy them by hand.
 
 ## Development Workflow
 

--- a/gradle-module-plugin/build.gradle.kts
+++ b/gradle-module-plugin/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 }
 
 group = "io.ia.sdk"
-version = "1.0.0"
+version = "1.1.0"
 
 
 testing {

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -25,6 +25,7 @@ import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.Jar
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.forEach
@@ -192,7 +193,6 @@ class IgnitionModlPlugin : Plugin<Project> {
             // descriptor without touching the project graph (configuration-cache safe).
             val scopeInputs = settings.projectScopes.get().mapNotNull { (projectPath, scope) ->
                 val sp = root.findProject(projectPath) ?: return@mapNotNull null
-
                 val classesDirs = root.objects.fileCollection()
                 sp.extensions.findByType(JavaPluginExtension::class.java)
                     ?.sourceSets?.findByName("main")
@@ -201,11 +201,17 @@ class IgnitionModlPlugin : Plugin<Project> {
                 classesDirs.from(sp.layout.projectDirectory.dir("out/production/classes"))
                 classesDirs.from(sp.layout.projectDirectory.dir("out/production/resources"))
 
+                // the subproject's own module jar, matched by exact archive name so a dependency
+                // that merely shares the project's name prefix isn't dropped (review finding #6)
+                val ownArtifactName = sp.tasks.withType(Jar::class.java)
+                    .findByName(JavaPlugin.JAR_TASK_NAME)
+                    ?.archiveFileName?.get().orEmpty()
                 val artifactJars = sp.fileTree("build/artifacts") { it.include("*.jar") }
 
-                WriteDevDescriptor.ScopeInput(scope, sp.name, classesDirs, artifactJars)
+                WriteDevDescriptor.ScopeInput(scope, ownArtifactName, classesDirs, artifactJars)
             }
             devTask.scopeInputs.set(scopeInputs)
+            devTask.dependsOn(assembleModuleStructure)
         }
 
         // task that zips up the folder of module content

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -11,6 +11,7 @@ import io.ia.sdk.gradle.modl.task.Checksum
 import io.ia.sdk.gradle.modl.task.CollectModlDependencies
 import io.ia.sdk.gradle.modl.task.ModuleBuildReport
 import io.ia.sdk.gradle.modl.task.SignModule
+import io.ia.sdk.gradle.modl.task.WriteDevDescriptor
 import io.ia.sdk.gradle.modl.task.WriteModuleXml
 import io.ia.sdk.gradle.modl.task.ZipModule
 import io.ia.sdk.gradle.modl.task.ZipModule.Companion.UNSIGNED_EXTENSION
@@ -166,6 +167,19 @@ class IgnitionModlPlugin : Plugin<Project> {
 
             // xml task depends on having module structure
             xmlTask.dependsOn(assembleModuleStructure)
+        }
+
+        // task that generates a dev module descriptor for IDE classloader isolation
+        root.tasks.register(
+            WriteDevDescriptor.ID,
+            WriteDevDescriptor::class.java
+        ) { devTask: WriteDevDescriptor ->
+            devTask.moduleId.set(settings.id)
+            devTask.moduleName.set(settings.name)
+            devTask.moduleVersion.set(settings.moduleVersion)
+            devTask.freeModule.set(settings.freeModule)
+            devTask.hookClasses.set(settings.hooks)
+            devTask.projectScopes.set(settings.projectScopes)
         }
 
         // task that zips up the folder of module content

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -23,7 +23,11 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.TaskProvider
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.forEach
 
 /**
  * Group used by all tasks so they show up in the appropriate category when 'gradle tasks' is executed
@@ -180,6 +184,28 @@ class IgnitionModlPlugin : Plugin<Project> {
             devTask.freeModule.set(settings.freeModule)
             devTask.hookClasses.set(settings.hooks)
             devTask.projectScopes.set(settings.projectScopes)
+            devTask.moduleDependencySpecs.set(settings.moduleDependencySpecs.toSet())
+
+            // Capture each scope's class output roots and dependency jars into task inputs at
+            // configuration time. The stored values are Gradle lazy types (FileCollection) and
+            // plain strings — no Project reference is retained — so the task action can build the
+            // descriptor without touching the project graph (configuration-cache safe).
+            val scopeInputs = settings.projectScopes.get().mapNotNull { (projectPath, scope) ->
+                val sp = root.findProject(projectPath) ?: return@mapNotNull null
+
+                val classesDirs = root.objects.fileCollection()
+                sp.extensions.findByType(JavaPluginExtension::class.java)
+                    ?.sourceSets?.findByName("main")
+                    ?.let { classesDirs.from(it.output) }
+                // IDEA-managed build output roots; only the ones present on disk are used at execution
+                classesDirs.from(sp.layout.projectDirectory.dir("out/production/classes"))
+                classesDirs.from(sp.layout.projectDirectory.dir("out/production/resources"))
+
+                val artifactJars = sp.fileTree("build/artifacts") { it.include("*.jar") }
+
+                WriteDevDescriptor.ScopeInput(scope, sp.name, classesDirs, artifactJars)
+            }
+            devTask.scopeInputs.set(scopeInputs)
         }
 
         // task that zips up the folder of module content

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/IgnitionModlPlugin.kt
@@ -172,7 +172,7 @@ class IgnitionModlPlugin : Plugin<Project> {
         // task that generates a dev module descriptor for IDE classloader isolation
         root.tasks.register(
             WriteDevDescriptor.ID,
-            WriteDevDescriptor::class.java
+            WriteDevDescriptor::class.java,
         ) { devTask: WriteDevDescriptor ->
             devTask.moduleId.set(settings.id)
             devTask.moduleName.set(settings.name)

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/extension/ModuleSettings.kt
@@ -116,16 +116,16 @@ abstract class ModuleSettings @javax.inject.Inject constructor(objects: ObjectFa
         objects.domainObjectContainer(ModuleDependencySpec::class.java)
 
     /**
-     * Map of Ignition Scope to fully qualified hook class to, where scope is one of "C", "D", "G" for "vision Client",
+     * Map of fully qualified hook class to Ignition Scope, where scope is one of "C", "D", "G" for "vision Client",
      * "Designer", and "Gateway" respectively.
      *
      * ### Examples:
      *
      * _Groovy_
-     *`  hooks = ["G": "com.example.gateway.GatewayModuleHook"]`
+     *`  hooks = ["com.example.gateway.GatewayModuleHook": "G"]`
      *
      * _Kotlin_
-     *`  hooks = mapOf("D" to "com.example.designer.MyDesignerHook")`
+     *`  hooks = mapOf("com.example.designer.MyDesignerHook" to "D")`
      */
     val hooks: MapProperty<String, String> = objects.mapProperty(String::class.java, String::class.java)
 

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/model/DevDescriptor.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/model/DevDescriptor.kt
@@ -15,20 +15,20 @@ data class DevModuleDescriptor(
     val hooks: Map<String, String> = emptyMap(),
     val moduleDependencies: List<DevModuleDependency> = emptyList(),
     val scopes: Map<String, DevScopeEntry> = emptyMap(),
-    val exports: Map<String, List<String>> = emptyMap()
+    val exports: Map<String, List<String>> = emptyMap(),
 )
 
 @JsonClass(generateAdapter = false)
 data class DevModuleDependency(
     val id: String,
     val scope: String,
-    val required: Boolean = false
+    val required: Boolean = false,
 )
 
 @JsonClass(generateAdapter = false)
 data class DevScopeEntry(
     val classDirs: Set<String> = emptySet(),
-    val jars: Set<String> = emptySet()
+    val jars: Set<String> = emptySet(),
 )
 
 fun DevModuleDescriptor.toJson(): String {

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/model/DevDescriptor.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/model/DevDescriptor.kt
@@ -1,0 +1,37 @@
+package io.ia.sdk.gradle.modl.model
+
+import com.squareup.moshi.JsonClass
+
+/**
+ * Data model for a dev module descriptor JSON file, used by the gateway to load modules
+ * from Gradle build outputs instead of .modl files for IDE classloader isolation.
+ */
+@JsonClass(generateAdapter = false)
+data class DevModuleDescriptor(
+    val id: String,
+    val name: String,
+    val version: String,
+    val freeModule: Boolean = false,
+    val hooks: Map<String, String> = emptyMap(),
+    val moduleDependencies: List<DevModuleDependency> = emptyList(),
+    val scopes: Map<String, DevScopeEntry> = emptyMap(),
+    val exports: Map<String, List<String>> = emptyMap()
+)
+
+@JsonClass(generateAdapter = false)
+data class DevModuleDependency(
+    val id: String,
+    val scope: String,
+    val required: Boolean = false
+)
+
+@JsonClass(generateAdapter = false)
+data class DevScopeEntry(
+    val classDirs: Set<String> = emptySet(),
+    val jars: Set<String> = emptySet()
+)
+
+fun DevModuleDescriptor.toJson(): String {
+    val adapter = MOSHI.adapter(DevModuleDescriptor::class.java).indent("  ")
+    return adapter.toJson(this)
+}

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteDevDescriptor.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteDevDescriptor.kt
@@ -1,0 +1,191 @@
+package io.ia.sdk.gradle.modl.task
+
+import io.ia.sdk.gradle.modl.extension.ModuleSettings
+import io.ia.sdk.gradle.modl.model.DevModuleDependency
+import io.ia.sdk.gradle.modl.model.DevModuleDescriptor
+import io.ia.sdk.gradle.modl.model.DevScopeEntry
+import io.ia.sdk.gradle.modl.model.toJson
+import org.gradle.api.DefaultTask
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import javax.inject.Inject
+
+/**
+ * Generates a JSON dev module descriptor for IDE classloader isolation.
+ *
+ * The descriptor contains module metadata (id, name, version, hooks, dependencies) along with
+ * per-scope class directories and dependency JARs collected from each subproject's build output.
+ *
+ * Class output directories are selected based on the IDE build delegation setting:
+ * - If IDEA manages the build (`delegatedBuild=false` in `.idea/gradle.xml`), the descriptor
+ *   uses `out/production/classes` paths.
+ * - If Gradle manages the build (delegated, or detection fails), the descriptor uses
+ *   `build/classes/{java,kotlin}/main` paths.
+ * - Fallback: if the detected mode's dirs don't exist but the other mode's do, the existing
+ *   dirs are used.
+ *
+ * All scope data is collected at execution time to avoid configuration-time ordering issues.
+ */
+open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : DefaultTask() {
+
+    companion object {
+        const val ID = "writeDevModuleDescriptor"
+    }
+
+    init {
+        group = "ignition development"
+        description = "Generates a dev module descriptor for IDE classloader isolation"
+    }
+
+    @get:Input
+    val moduleId: Property<String> = objects.property(String::class.java)
+
+    @get:Input
+    val moduleName: Property<String> = objects.property(String::class.java)
+
+    @get:Input
+    val moduleVersion: Property<String> = objects.property(String::class.java)
+
+    @get:Input
+    val freeModule: Property<Boolean> = objects.property(Boolean::class.javaObjectType)
+
+    /** Hook classes as configured in the extension: className -> scopeLetter */
+    @get:Input
+    val hookClasses: MapProperty<String, String> =
+        objects.mapProperty(String::class.java, String::class.java)
+
+    /** Project path -> scope letter(s) mapping from the extension */
+    @get:Input
+    val projectScopes: MapProperty<String, String> =
+        objects.mapProperty(String::class.java, String::class.java)
+
+    @OutputFile
+    fun getOutputFile(): File {
+        return project.layout.buildDirectory.file("dev/${moduleId.get()}.json").get().asFile
+    }
+
+    @TaskAction
+    fun execute() {
+        val settings = project.extensions.findByType(ModuleSettings::class.java)
+        val ideaBuilds = detectIdeaBuildMode()
+
+        if (ideaBuilds) {
+            logger.info("Detected IDEA-managed builds (delegatedBuild=false). Using out/production/ class dirs.")
+        } else {
+            logger.info("Using Gradle build output class dirs.")
+        }
+
+        val descriptor = DevModuleDescriptor(
+            id = moduleId.get(),
+            name = moduleName.get(),
+            version = moduleVersion.get(),
+            freeModule = freeModule.get(),
+            hooks = hookClasses.get().entries.associate { (className, scope) -> scope to className },
+            moduleDependencies = collectDependencySpecs(settings),
+            scopes = collectScopeData(ideaBuilds),
+            exports = emptyMap()
+        )
+
+        val outFile = getOutputFile()
+        outFile.parentFile.mkdirs()
+        outFile.writeText(descriptor.toJson())
+        logger.lifecycle("Wrote dev module descriptor: ${outFile.absolutePath}")
+    }
+
+    /**
+     * Detects whether IDEA is managing the build by reading `.idea/gradle.xml`.
+     * Returns `true` if `delegatedBuild` is explicitly set to `false`.
+     */
+    private fun detectIdeaBuildMode(): Boolean {
+        val gradleXml = project.rootProject.file(".idea/gradle.xml")
+        if (!gradleXml.exists()) return false
+        return try {
+            val content = gradleXml.readText()
+            content.contains("""delegatedBuild" value="false""")
+        } catch (e: Exception) {
+            logger.debug("Could not read .idea/gradle.xml: ${e.message}")
+            false
+        }
+    }
+
+    private fun collectDependencySpecs(settings: ModuleSettings?): List<DevModuleDependency> {
+        return settings?.moduleDependencySpecs?.map { spec ->
+            DevModuleDependency(
+                id = spec.name,
+                scope = spec.scope,
+                required = spec.required
+            )
+        } ?: emptyList()
+    }
+
+    /**
+     * Collects class directories and dependency JARs for each scope.
+     *
+     * @param ideaBuilds true if IDEA manages the build (use out/production/), false for Gradle (use build/classes/)
+     */
+    private fun collectScopeData(ideaBuilds: Boolean): Map<String, DevScopeEntry> {
+        val scopeMap = mutableMapOf<String, Pair<MutableSet<String>, MutableSet<String>>>()
+
+        projectScopes.get().forEach { (projectPath, scope) ->
+            val subproj = project.rootProject.findProject(projectPath) ?: return@forEach
+            val (classDirs, jars) = scopeMap.getOrPut(scope) {
+                mutableSetOf<String>() to mutableSetOf()
+            }
+
+            if (ideaBuilds) {
+                // IDEA-managed build: use out/production/classes
+                val ideaOutDir = subproj.file("out/production/classes")
+                classDirs.add(ideaOutDir.absolutePath)
+
+                // Fallback: if out/ doesn't exist but build/classes does, include build/ too
+                if (!ideaOutDir.isDirectory) {
+                    addGradleClassDirs(subproj, classDirs)
+                }
+            } else {
+                // Gradle-delegated build: use build/classes/*/main
+                addGradleClassDirs(subproj, classDirs)
+
+                // Fallback: if build/classes doesn't exist but out/ does, include out/
+                val buildClassesDir = subproj.file("build/classes")
+                if (!buildClassesDir.isDirectory) {
+                    val ideaOutDir = subproj.file("out/production/classes")
+                    if (ideaOutDir.isDirectory) {
+                        classDirs.add(ideaOutDir.absolutePath)
+                    }
+                }
+            }
+
+            // Resources — always from Gradle's build dir (IDEA uses the same path)
+            val resourcesDir = subproj.file("build/resources/main")
+            classDirs.add(resourcesDir.absolutePath)
+
+            // Resolved dependency JARs from collectModlDependencies output
+            val artifactsDir = subproj.file("build/artifacts")
+            val subprojName = subproj.name
+            if (artifactsDir.isDirectory) {
+                artifactsDir.listFiles()
+                    ?.filter { it.name.endsWith(".jar") && !it.name.startsWith(subprojName) }
+                    ?.forEach { jar -> jars.add(jar.absolutePath) }
+            }
+        }
+
+        return scopeMap.mapValues { (_, pair) ->
+            DevScopeEntry(classDirs = pair.first, jars = pair.second)
+        }
+    }
+
+    /** Adds Gradle class output directories (build/classes/java/main, build/classes/kotlin/main, etc.) */
+    private fun addGradleClassDirs(subproj: org.gradle.api.Project, classDirs: MutableSet<String>) {
+        val javaExt = subproj.extensions.findByType(org.gradle.api.plugins.JavaPluginExtension::class.java)
+        javaExt?.sourceSets?.findByName("main")?.let { mainSourceSet ->
+            mainSourceSet.output.classesDirs.files.forEach { dir ->
+                classDirs.add(dir.absolutePath)
+            }
+        }
+    }
+}

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteDevDescriptor.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteDevDescriptor.kt
@@ -9,6 +9,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -31,6 +32,7 @@ import javax.inject.Inject
  *
  * All scope data is collected at execution time to avoid configuration-time ordering issues.
  */
+@CacheableTask
 open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : DefaultTask() {
 
     companion object {
@@ -65,9 +67,7 @@ open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : Defa
         objects.mapProperty(String::class.java, String::class.java)
 
     @OutputFile
-    fun getOutputFile(): File {
-        return project.layout.buildDirectory.file("dev/${moduleId.get()}.json").get().asFile
-    }
+    fun getOutputFile(): File = project.layout.buildDirectory.file("dev/${moduleId.get()}.json").get().asFile
 
     @TaskAction
     fun execute() {
@@ -88,7 +88,7 @@ open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : Defa
             hooks = hookClasses.get().entries.associate { (className, scope) -> scope to className },
             moduleDependencies = collectDependencySpecs(settings),
             scopes = collectScopeData(ideaBuilds),
-            exports = emptyMap()
+            exports = emptyMap(),
         )
 
         val outFile = getOutputFile()
@@ -113,15 +113,13 @@ open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : Defa
         }
     }
 
-    private fun collectDependencySpecs(settings: ModuleSettings?): List<DevModuleDependency> {
-        return settings?.moduleDependencySpecs?.map { spec ->
-            DevModuleDependency(
-                id = spec.name,
-                scope = spec.scope,
-                required = spec.required
-            )
-        } ?: emptyList()
-    }
+    private fun collectDependencySpecs(settings: ModuleSettings?): List<DevModuleDependency> = settings?.moduleDependencySpecs?.map { spec ->
+        DevModuleDependency(
+            id = spec.name,
+            scope = spec.scope,
+            required = spec.required,
+        )
+    } ?: emptyList()
 
     /**
      * Collects class directories and dependency JARs for each scope.

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteDevDescriptor.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteDevDescriptor.kt
@@ -50,8 +50,9 @@ open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : Defa
         @get:Input
         val scope: String,
 
+        /** Archive file name of the subproject's own module jar, excluded from dependency jars. */
         @get:Input
-        val projectName: String,
+        val ownArtifactName: String,
 
         // lazy Gradle types are CC-serializable; classes dirs feed both @InputFiles and the descriptor
         @get:InputFiles
@@ -104,7 +105,7 @@ open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : Defa
     val scopeInputs: ListProperty<ScopeInput> = objects.listProperty(ScopeInput::class.java)
 
     @get:OutputFile
-    val outPutFile: RegularFileProperty = objects.fileProperty().convention(
+    val outputFile: RegularFileProperty = objects.fileProperty().convention(
         project.layout.buildDirectory.file(moduleId.map { "dev/$it.json" }),
     )
 
@@ -121,7 +122,7 @@ open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : Defa
             exports = emptyMap(),
         )
 
-        val outFile = outPutFile.get().asFile
+        val outFile = outputFile.get().asFile
         outFile.parentFile.mkdirs()
         outFile.writeText(descriptor.toJson())
         logger.lifecycle("Wrote dev module descriptor: ${outFile.absolutePath}")
@@ -153,7 +154,7 @@ open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : Defa
                 .forEach { classDirs.add(it.absolutePath) }
 
             input.artifactJars.files
-                .filter { it.name.endsWith(".jar") && !it.name.startsWith(input.projectName) }
+                .filter { it.name.endsWith(".jar") && it.name != input.ownArtifactName }
                 .forEach { jars.add(it.absolutePath) }
         }
 

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteDevDescriptor.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteDevDescriptor.kt
@@ -1,19 +1,26 @@
 package io.ia.sdk.gradle.modl.task
 
-import io.ia.sdk.gradle.modl.extension.ModuleSettings
+import io.ia.sdk.gradle.modl.extension.ModuleDependencySpec
 import io.ia.sdk.gradle.modl.model.DevModuleDependency
 import io.ia.sdk.gradle.modl.model.DevModuleDescriptor
 import io.ia.sdk.gradle.modl.model.DevScopeEntry
 import io.ia.sdk.gradle.modl.model.toJson
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
-import java.io.File
 import javax.inject.Inject
 
 /**
@@ -22,18 +29,39 @@ import javax.inject.Inject
  * The descriptor contains module metadata (id, name, version, hooks, dependencies) along with
  * per-scope class directories and dependency JARs collected from each subproject's build output.
  *
- * Class output directories are selected based on the IDE build delegation setting:
- * - If IDEA manages the build (`delegatedBuild=false` in `.idea/gradle.xml`), the descriptor
- *   uses `out/production/classes` paths.
- * - If Gradle manages the build (delegated, or detection fails), the descriptor uses
- *   `build/classes/{java,kotlin}/main` paths.
- * - Fallback: if the detected mode's dirs don't exist but the other mode's do, the existing
- *   dirs are used.
+ * All project-graph data (per-scope class output roots and dependency jars) is captured into task
+ * inputs at configuration time via [scopeInputs] and [moduleDependencySpecs], so the task action
+ * never touches the `Project` object at execution time. This keeps the task compatible with
+ * Gradle's configuration cache.
  *
- * All scope data is collected at execution time to avoid configuration-time ordering issues.
+ * Both the Gradle build output roots (`build/classes/{java,kotlin}/main`, `build/resources/main`)
+ * and the IDEA-managed roots (`out/production/{classes,resources}`) are captured up front; at
+ * execution time only the directories that actually exist on disk are written into the descriptor,
+ * so no `.idea/gradle.xml` IDE-mode detection is needed.
  */
 @CacheableTask
 open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : DefaultTask() {
+
+    /**
+     * A single project's contribution to one Ignition scope. Multiple entries may share the same
+     * [scope] when more than one subproject targets it; they are merged at execution time.
+     */
+    data class ScopeInput(
+        @get:Input
+        val scope: String,
+
+        @get:Input
+        val projectName: String,
+
+        // lazy Gradle types are CC-serializable; classes dirs feed both @InputFiles and the descriptor
+        @get:InputFiles
+        @get:PathSensitive(PathSensitivity.RELATIVE)
+        val classesDirs: FileCollection,
+
+        @get:InputFiles
+        @get:PathSensitive(PathSensitivity.RELATIVE)
+        val artifactJars: FileCollection,
+    )
 
     companion object {
         const val ID = "writeDevModuleDescriptor"
@@ -66,124 +94,71 @@ open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : Defa
     val projectScopes: MapProperty<String, String> =
         objects.mapProperty(String::class.java, String::class.java)
 
-    @OutputFile
-    fun getOutputFile(): File = project.layout.buildDirectory.file("dev/${moduleId.get()}.json").get().asFile
+    /** Module dependency specs captured from the extension at configuration time. */
+    @get:Input
+    val moduleDependencySpecs: SetProperty<ModuleDependencySpec> =
+        objects.setProperty(ModuleDependencySpec::class.java)
+
+    /** Per-project, per-scope class dirs and dependency jars, captured at configuration time. */
+    @get:Nested
+    val scopeInputs: ListProperty<ScopeInput> = objects.listProperty(ScopeInput::class.java)
+
+    @get:OutputFile
+    val outPutFile: RegularFileProperty = objects.fileProperty().convention(
+        project.layout.buildDirectory.file(moduleId.map { "dev/$it.json" }),
+    )
 
     @TaskAction
     fun execute() {
-        val settings = project.extensions.findByType(ModuleSettings::class.java)
-        val ideaBuilds = detectIdeaBuildMode()
-
-        if (ideaBuilds) {
-            logger.info("Detected IDEA-managed builds (delegatedBuild=false). Using out/production/ class dirs.")
-        } else {
-            logger.info("Using Gradle build output class dirs.")
-        }
-
         val descriptor = DevModuleDescriptor(
             id = moduleId.get(),
             name = moduleName.get(),
             version = moduleVersion.get(),
             freeModule = freeModule.get(),
             hooks = hookClasses.get().entries.associate { (className, scope) -> scope to className },
-            moduleDependencies = collectDependencySpecs(settings),
-            scopes = collectScopeData(ideaBuilds),
+            moduleDependencies = collectDependencySpecs(),
+            scopes = collectScopeData(),
             exports = emptyMap(),
         )
 
-        val outFile = getOutputFile()
+        val outFile = outPutFile.get().asFile
         outFile.parentFile.mkdirs()
         outFile.writeText(descriptor.toJson())
         logger.lifecycle("Wrote dev module descriptor: ${outFile.absolutePath}")
     }
 
-    /**
-     * Detects whether IDEA is managing the build by reading `.idea/gradle.xml`.
-     * Returns `true` if `delegatedBuild` is explicitly set to `false`.
-     */
-    private fun detectIdeaBuildMode(): Boolean {
-        val gradleXml = project.rootProject.file(".idea/gradle.xml")
-        if (!gradleXml.exists()) return false
-        return try {
-            val content = gradleXml.readText()
-            content.contains("""delegatedBuild" value="false""")
-        } catch (e: Exception) {
-            logger.debug("Could not read .idea/gradle.xml: ${e.message}")
-            false
-        }
-    }
-
-    private fun collectDependencySpecs(settings: ModuleSettings?): List<DevModuleDependency> = settings?.moduleDependencySpecs?.map { spec ->
+    private fun collectDependencySpecs(): List<DevModuleDependency> = moduleDependencySpecs.get().map { spec ->
         DevModuleDependency(
             id = spec.name,
             scope = spec.scope,
             required = spec.required,
         )
-    } ?: emptyList()
+    }
 
     /**
-     * Collects class directories and dependency JARs for each scope.
-     *
-     * @param ideaBuilds true if IDEA manages the build (use out/production/), false for Gradle (use build/classes/)
+     * Merges the captured [scopeInputs] into a per-scope map of class dirs and dependency jars.
+     * Only class directories that exist on disk are included, which transparently covers both
+     * IDEA-managed (out/production) and Gradle-managed (build/classes) build outputs.
      */
-    private fun collectScopeData(ideaBuilds: Boolean): Map<String, DevScopeEntry> {
+    private fun collectScopeData(): Map<String, DevScopeEntry> {
         val scopeMap = mutableMapOf<String, Pair<MutableSet<String>, MutableSet<String>>>()
 
-        projectScopes.get().forEach { (projectPath, scope) ->
-            val subproj = project.rootProject.findProject(projectPath) ?: return@forEach
-            val (classDirs, jars) = scopeMap.getOrPut(scope) {
+        scopeInputs.get().forEach { input ->
+            val (classDirs, jars) = scopeMap.getOrPut(input.scope) {
                 mutableSetOf<String>() to mutableSetOf()
             }
 
-            if (ideaBuilds) {
-                // IDEA-managed build: use out/production/classes
-                val ideaOutDir = subproj.file("out/production/classes")
-                classDirs.add(ideaOutDir.absolutePath)
+            input.classesDirs.files
+                .filter { it.exists() }
+                .forEach { classDirs.add(it.absolutePath) }
 
-                // Fallback: if out/ doesn't exist but build/classes does, include build/ too
-                if (!ideaOutDir.isDirectory) {
-                    addGradleClassDirs(subproj, classDirs)
-                }
-            } else {
-                // Gradle-delegated build: use build/classes/*/main
-                addGradleClassDirs(subproj, classDirs)
-
-                // Fallback: if build/classes doesn't exist but out/ does, include out/
-                val buildClassesDir = subproj.file("build/classes")
-                if (!buildClassesDir.isDirectory) {
-                    val ideaOutDir = subproj.file("out/production/classes")
-                    if (ideaOutDir.isDirectory) {
-                        classDirs.add(ideaOutDir.absolutePath)
-                    }
-                }
-            }
-
-            // Resources — always from Gradle's build dir (IDEA uses the same path)
-            val resourcesDir = subproj.file("build/resources/main")
-            classDirs.add(resourcesDir.absolutePath)
-
-            // Resolved dependency JARs from collectModlDependencies output
-            val artifactsDir = subproj.file("build/artifacts")
-            val subprojName = subproj.name
-            if (artifactsDir.isDirectory) {
-                artifactsDir.listFiles()
-                    ?.filter { it.name.endsWith(".jar") && !it.name.startsWith(subprojName) }
-                    ?.forEach { jar -> jars.add(jar.absolutePath) }
-            }
+            input.artifactJars.files
+                .filter { it.name.endsWith(".jar") && !it.name.startsWith(input.projectName) }
+                .forEach { jars.add(it.absolutePath) }
         }
 
         return scopeMap.mapValues { (_, pair) ->
             DevScopeEntry(classDirs = pair.first, jars = pair.second)
-        }
-    }
-
-    /** Adds Gradle class output directories (build/classes/java/main, build/classes/kotlin/main, etc.) */
-    private fun addGradleClassDirs(subproj: org.gradle.api.Project, classDirs: MutableSet<String>) {
-        val javaExt = subproj.extensions.findByType(org.gradle.api.plugins.JavaPluginExtension::class.java)
-        javaExt?.sourceSets?.findByName("main")?.let { mainSourceSet ->
-            mainSourceSet.output.classesDirs.files.forEach { dir ->
-                classDirs.add(dir.absolutePath)
-            }
         }
     }
 }

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteDevDescriptor.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteDevDescriptor.kt
@@ -116,16 +116,32 @@ open class WriteDevDescriptor @Inject constructor(objects: ObjectFactory) : Defa
             name = moduleName.get(),
             version = moduleVersion.get(),
             freeModule = freeModule.get(),
-            hooks = hookClasses.get().entries.associate { (className, scope) -> scope to className },
+            hooks = invertHooksByScope(hookClasses.get()),
             moduleDependencies = collectDependencySpecs(),
             scopes = collectScopeData(),
-            exports = emptyMap(),
         )
 
         val outFile = outputFile.get().asFile
         outFile.parentFile.mkdirs()
         outFile.writeText(descriptor.toJson())
         logger.lifecycle("Wrote dev module descriptor: ${outFile.absolutePath}")
+    }
+
+    /**
+     * Inverts the configured `className -> scope` hook map into the descriptor's `scope -> className`
+     * form. Fails with a friendly error if two hook classes are declared for the same scope, since a
+     * silent inversion would otherwise drop one of them.
+     */
+    private fun invertHooksByScope(hooks: Map<String, String>): Map<String, String> {
+        val byScope = mutableMapOf<String, String>()
+        hooks.forEach { (className, scope) ->
+            val existing = byScope.putIfAbsent(scope, className)
+            require(existing == null) {
+                "Multiple hook classes declared for scope '$scope': '$existing' and '$className'. " +
+                    "Each Ignition scope may declare at most one hook class."
+            }
+        }
+        return byScope
     }
 
     private fun collectDependencySpecs(): List<DevModuleDependency> = moduleDependencySpecs.get().map { spec ->

--- a/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
+++ b/gradle-module-plugin/src/main/kotlin/io/ia/sdk/gradle/modl/task/WriteModuleXml.kt
@@ -229,7 +229,7 @@ open class WriteModuleXml @Inject constructor(_objects: ObjectFactory) : Default
         if (!requiredIgnitionVersion.isPresent) return false
 
         val version = requiredIgnitionVersion.get().split(".").map { it.toInt() }
-        if (version[0] >= 9) {
+        if (version[0] >= 2027) {
             return true
         }
         if (version[0] == 8 && version[1] >= 3) {


### PR DESCRIPTION
### Problem:
Running gateway in IntelliJ as a Gradle project will emit the following error:
java.lang.NoClassDefFoundError: javax/activation/DataSource

### Fix:
Please refer to the new 'IDE Development with Dev Module Descriptors' section added to the README.md file for detailed implementation.  It has improved how dependency loading mechanism works for gateway running in IDE through devDescriptor. 


Fixes: IGN-15978